### PR TITLE
Move TrialScope-specific code to the service

### DIFF
--- a/mapping.js
+++ b/mapping.js
@@ -1,8 +1,12 @@
 const jsonMapping = require('./condition_snomed.json');
 
-/* Takes (str) list of snomed codes and returns (str)
-list of related trialscope conditions for all codes*/
-exports.mapConditions = function (codeList) {
+/**
+ * Takes (str) list of snomed codes and returns (str)
+ * list of related trialscope conditions for all codes
+ * @param {string[]} codeList the list of codes
+ * @return {Set<string>} a set of codes
+ */
+exports.mapConditions = function(codeList) {
   let conditions = new Set();
   for (let index = 0; index < codeList.length; index++) {
     conditions = union(conditions, codeToConditions(codeList[index]));
@@ -10,11 +14,15 @@ exports.mapConditions = function (codeList) {
   return conditions;
 };
 
-/* Takes snomed code (str) and returns (str) list
-of related trialscope conditions */
+/**
+ * Takes snomed code (str) and returns (str) list
+ * of related trialscope conditions
+ * @param {string} code the code to look up
+ * @return {Set<string>} a set of codes
+ */
 function codeToConditions(code) {
   let conditions = new Set();
-  for (let term in jsonMapping){
+  for (let term in jsonMapping) {
     if (jsonMapping[term].includes(code)) {
       conditions.add(term);
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/server.js
+++ b/server.js
@@ -2,14 +2,18 @@ const mapping = require('./mapping'),
   express = require('express'),
   bodyParser = require('body-parser'),
   config = require('./env.js'),
+  { runTrialScopeQuery, runRawTrialScopeQuery } = require('./trialscope'),
   fetch = require('node-fetch');
 
 const app = express(),
   environment = new config().defaultEnvObject();
 
-app.use(bodyParser.json());
+app.use(bodyParser.json({
+  // Need to increase the payload limit to receive patient bundles
+  limit: "10MB"
+}));
 
-app.use(function (_req, res, next) {
+app.use(function(_req, res, next) {
   // Website you wish to allow to connect
   res.setHeader('Access-Control-Allow-Origin', '*');
 
@@ -23,76 +27,53 @@ app.use(function (_req, res, next) {
 });
 
 /* Default call*/
-app.get('/', function (_req, res) {
+app.get('/', function(_req, res) {
   res.status(200).send('Hello from Clinical Trial');
 });
 
 /* get trialscope conditions (str) list from code (str) list */
-app.post('/getConditions', function (req, res) {
-  let codeList = req.body;
-  let conditions = mapping.mapConditions(codeList);
-  let result = JSON.stringify(Array.from(conditions));
+app.post('/getConditions', function(req, res) {
+  const codeList = req.body;
+  const conditions = mapping.mapConditions(codeList);
+  const result = JSON.stringify(Array.from(conditions));
   res.status(200).send(result);
 });
 
 /* The api request will be mainly created in this file
 
 @param bundled_query - the string json object of search parameters with the number of results/page and starting place
-  
+
 Call this function in the server
 
 */
 function createRequest(bundled_query) {
-  let query = bundled_query.query;
-  let first = bundled_query.first;
-  let after = bundled_query.after;
-  var input =
-    `
-    {
-      baseMatches(first: ${first} after: ${JSON.stringify(after)} ${query})
-    {
-      totalCount
-      edges {
-        node {
-          nctId title conditions gender description detailedDescription
-          criteria sponsor overallContactPhone overallContactEmail
-          overallStatus armGroups phase minimumAge studyType
-          maximumAge sites {
-            facility contactName contactEmail contactPhone latitude longitude
-          }
-        }
-        cursor
-      }
-      pageInfo { endCursor hasNextPage }
-    } }`
-  return input;
+  console.log(bundled_query);
+  return bundled_query.inputParam;
 }
 
 
-/* get clinical trial results*/
-app.post('/getClinicalTrial', function (req, res) {
-  const myHeaders = new fetch.Headers;
-  myHeaders.append('Content-Type', 'application/json');
-  myHeaders.append('Authorization', 'Bearer ' + environment.token);
-
-  let input = createRequest(req.body)
-  const raw = JSON.stringify({ query: input });
-
-  const requestOptions = {
-    method: 'POST',
-    headers: myHeaders,
-    body: raw,
-    redirect: 'follow'
-  };
-
-  fetch(environment.trialscope_endpoint, requestOptions)
-    .then(response => response.text())
-    .then(result => {
-      res.status(200).send(result);
-    })
-    .catch(error => {
-      res.status(400).send(error);
+/**
+ * Get clinical trial results (the "main" API).
+ */
+app.post('/getClinicalTrial', function(req, res) {
+  if ('patientData' in req.body) {
+    const patientBundle = typeof req.body.patientData === 'string' ? JSON.parse(req.body.patientData) : req.body.patientData;
+    runTrialScopeQuery(patientBundle).then(result => {
+      res.status(200).send(JSON.stringify(result));
+    }).catch(error => {
+      console.error(error);
+      res.status(500).send(`"Error from server"`);
     });
+  } else {
+    // Backwards-compat: if there is no patient body, just run the query directly
+    runRawTrialScopeQuery(req.body.inputParam).then(result => {
+      res.status(200).send(result);
+    }).catch(error => {
+      console.error(error);
+      res.status(400).send({ error: error.toString() });
+    });
+    return;
+  }
 });
 
 app.use(express.static('public'));

--- a/trialscope.js
+++ b/trialscope.js
@@ -1,0 +1,152 @@
+/**
+ * Module for dealing with TrialScope
+ */
+const https = require('https'),
+  mapConditions = require('./mapping').mapConditions;
+
+const environment = new (require('./env'))().defaultEnvObject();
+
+if (typeof environment.token !== 'string' || environment.token === '') {
+  throw new Error('TrialScope token is not set in environment.');
+}
+
+class TrialScopeError extends Error {
+  constructor(message, result, body) {
+    super(message);
+    this.result = result;
+    this.body = body;
+  }
+}
+
+/**
+ * Object for storing the various parameters necessary for the TrialScope query
+ * based on a patient bundle.
+ */
+class TrialScopeQuery {
+  constructor(patientBundle) {
+    this.conditions = new Set();
+    this.zipCode = null;
+    this.travelRadius = null;
+    this.phase = 'any';
+    this.recruitmentStatus = 'all';
+    for (const entry of patientBundle.entry) {
+      if (!('resource' in entry)) {
+        // Skip bad entries
+        continue;
+      }
+      const resource = entry.resource;
+      console.log(`Checking resource ${resource.resourceType}`);
+      if (resource.resourceType === 'Parameters') {
+        for (const parameter of resource.parameter) {
+          console.log(` - Setting parameter ${parameter.name} to ${parameter.valueString}`);
+          if (parameter.name === 'zipCode') {
+            this.zipCode = parameter.valueString;
+          } else if (parameter.name === 'travelRadius') {
+            this.travelRadius = parseFloat(parameter.valueString);
+          } else if (parameter.name === 'phase') {
+            this.phase = parameter.valueString;
+          } else if (parameter.name === 'recruitmentStatus') {
+            this.recruitmentStatus = parameter.valueString;
+          }
+        }
+      }
+      if (resource.resourceType === 'Condition') {
+        this.addCondition(resource);
+      }
+    }
+  }
+  addCondition(condition) {
+    // Should have a code
+    // TODO: Limit to specific coding systems (maybe)
+    for (const code of condition.code.coding) {
+      this.conditions.add(code.code);
+    }
+  }
+  getTrialScopeConditions() {
+    return mapConditions(Array.from(this.conditions));
+  }
+  /**
+   * Create a TrialScope query.
+   * @return {string} the TrialScope GraphQL query
+   */
+  toQuery() {
+    let baseMatches = `conditions:[${Array.from(this.getTrialScopeConditions()).join(', ')}], baseFilters: { zipCode: "${this.zipCode}"`;
+    if (this.travelRadius) {
+      // FIXME: Veryify travel radius is a number
+      baseMatches += ',travelRadius: ' + this.travelRadius;
+    }
+    if (this.phase !== 'any') {
+      baseMatches += ',phase:' + this.phase;
+    }
+    if (this.recruitmentStatus !== 'all') {
+      baseMatches += ',recruitmentStatus:' + this.recruitmentStatus;
+    }
+    baseMatches += ' }';
+    let query = `{ baseMatches(${baseMatches}) {` +
+      'totalCount edges {' +
+        'node {' +
+          'nctId title conditions gender description detailedDescription ' +
+          'criteria sponsor overallContactPhone overallContactEmail ' +
+          'overallStatus armGroups phase minimumAge studyType ' +
+          'maximumAge sites { ' +
+            'facility contactName contactEmail contactPhone latitude longitude ' +
+          '} ' +
+        '} ' +
+        'cursor ' +
+      '} ' +
+      'pageInfo { endCursor hasNextPage }' +
+    '} }';
+    console.log('Generated query:');
+    console.log(query);
+    return query;
+  }
+}
+
+function runTrialScopeQuery(patientBundle) {
+  console.log('Creating TrialScope query...');
+  return runQuery(new TrialScopeQuery(patientBundle).toQuery());
+}
+
+/**
+ * Runs the query directly.
+ * @param {string} query the query to run
+ */
+function runQuery(query) {
+  return new Promise((resolve, reject) => {
+    const body = Buffer.from(`{"query":${JSON.stringify(query)}}`, 'utf8');
+    console.log('Running raw TrialScope query');
+    console.log(query);
+    const request = https.request(environment.trialscope_endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=UTF-8',
+        'Content-Length': body.byteLength.toString(),
+        'Authorization': 'Bearer ' + environment.token
+      }
+    }, result => {
+      let responseBody = '';
+      result.on('data', chunk => {
+        responseBody += chunk;
+      });
+      result.on('end', () => {
+        console.log('Complete');
+        if (result.statusCode === 200) {
+          resolve(JSON.parse(responseBody));
+        } else {
+          reject(new TrialScopeError(`Server returned ${result.statusCode} ${result.statusMessage}`, result, responseBody));
+        }
+      });
+    });
+
+    request.on('error', error => reject(error));
+
+    request.write(body);
+    request.end();
+  });
+}
+
+module.exports = {
+  runTrialScopeQuery: runTrialScopeQuery,
+  runRawTrialScopeQuery: runQuery,
+  TrialScopeQuery: TrialScopeQuery
+};


### PR DESCRIPTION
This moves the TrialScope-specific interaction code into the service. It leaves the conditions and the ability to run a TrialScope query directly (by not including the patient bundle and forming the request like it used to be created) intact, making it backwards-compatible (at least in theory) with the current web front-end code.