### PR TITLE
Fix the TypeScript configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,7 @@ module.exports = {
       parserOptions: {
         ecmaVersion: 2020,
         sourceType: 'module',
-        project: 'tsconfig.json'
+        project: 'tsconfig.lint.json'
       },
       plugins: [
         '@typescript-eslint'

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Ignore built files
 /dist
+/dist-spec
 
 # Ignore installed modules
 /node_modules

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "target": "es6",
+    "noImplicitAny": false,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "node_modules/*",
+        "src/types/*"
+      ]
+    }
+  }
+}

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "./src/**/*",
+    "./spec/**/*"
+  ]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist-spec"
   },
   "include": [
-    "./src/**/*"
+    "./spec/**/*"
   ]
 }


### PR DESCRIPTION
This fixes the build so that the source files are built under /dist as they expect, and keeps the lint working on the spec files as well as the source files.