### PR TITLE
Add exception handler to server

### DIFF
--- a/spec/support/server.spec.ts
+++ b/spec/support/server.spec.ts
@@ -1,15 +1,19 @@
 import request from 'supertest';
 import server from '../../src/server';
+import * as trialscope from '../../src/trialscope';
 
-describe("server tests", () => {
-  it("responds to /", () => {
+describe('server', () => {
+  // Reset the request generator after each test (currently gets modified only
+  // in one test)
+  afterEach(() => { trialscope.setRequestGenerator(); });
+  it('responds to /', () => {
     return request(server)
       .get('/')
       .set('Accept', 'application/json')
       .expect(200);
   });
 
-  it("responds to / with hello from clinical trial ", () => {
+  it('responds to / with hello from clinical trial', () => {
     return request(server)
       .get('/')
       .set('Accept', 'application/json')
@@ -19,14 +23,14 @@ describe("server tests", () => {
       });
   });
 
-  it("responds to /getConditions ", () => {
+  it('responds to /getConditions', () => {
     return request(server)
       .post('/getConditions')
       .set('Accept', 'application/json')
       .expect(200);
   });
 
-  it("responds to /getClinicalTrial with improper patient bundle ", () => {
+  it('responds to /getClinicalTrial with improper patient bundle', () => {
     return request(server)
       .post('/getClinicalTrial')
       .send({ patientData: {} })
@@ -34,13 +38,28 @@ describe("server tests", () => {
       .expect(400);
   });
 
-  it("responds to /getClinicalTrial with no patientBundle param  ", () => {
+  it('responds to /getClinicalTrial with no patientBundle param', () => {
     return request(server)
       .post('/getClinicalTrial')
       .send({})
       .set('Accept', 'application/json')
       .expect(400);
-   });
+  });
+
+  it('handles request failing', () => {
+    trialscope.setRequestGenerator(jasmine.createSpy('https.request').and.throwError('Example request error'));
+    return request(server)
+      .post('/getClinicalTrial')
+      .send({
+        patientData: {
+          resourceType: 'Bundle',
+          type: 'collection',
+          entry: [ ]
+        }
+      })
+      .set('Accept', 'application/json')
+      .expect(500);
+  });
 });
 
 

--- a/spec/trialscope.spec.ts
+++ b/spec/trialscope.spec.ts
@@ -1,0 +1,21 @@
+import { isTrialScopeResponse, isTrialScopeErrorResponse } from '../src/trialscope';
+
+describe('isTrialScopeResponse', () => {
+  it('does not fail with a null data field', () => {
+    expect(isTrialScopeResponse({ data: null })).toBe(false);
+  });
+  it('does not fail with a null baseMatches field', () => {
+    expect(isTrialScopeResponse({ data: { baseMatches: null } })).toBe(false);
+  });
+});
+
+describe('isTrialScopeErrorResponse', () => {
+  it('does not fail with a null error field', () => {
+    expect(isTrialScopeErrorResponse({ errors: null })).toBe(false);
+  });
+  it('requires errors be an array', () => {
+    expect(isTrialScopeErrorResponse({ errors: [ ] })).toBe(true);
+    expect(isTrialScopeErrorResponse({ errors: 5 })).toBe(false);
+  })
+});
+

--- a/src/request-error.ts
+++ b/src/request-error.ts
@@ -1,0 +1,17 @@
+/**
+ * Simply marks an error as a request error: the client request was bad. May
+ * specify a different HTTP status error. Any error outside the 400 range will
+ * be translated to 400.
+ */
+export default class RequestError extends Error {
+  private _httpStatus: number;
+  constructor(message: string, httpStatus = 400) {
+    super(message);
+    if (httpStatus < 400 || httpStatus >= 500) {
+      httpStatus = 400;
+    }
+    this._httpStatus = Math.floor(httpStatus);
+  }
+
+  get httpStatus(): number { return this._httpStatus; }
+}

--- a/src/trialscope.ts
+++ b/src/trialscope.ts
@@ -77,13 +77,15 @@ export interface TrialScopeResponse {
   }
 }
 
-function isTrialScopeResponse(o: unknown): o is TrialScopeResponse {
+export function isTrialScopeResponse(o: unknown): o is TrialScopeResponse {
   if (typeof o !== 'object') {
     return false;
   }
-  if ('data' in o) {
+  if ('data' in o && typeof o['data'] === 'object' && o['data'] !== null) {
     const possibleResponse = o as TrialScopeResponse;
-    return 'baseMatches' in possibleResponse.data;
+    return 'baseMatches' in possibleResponse.data
+      && typeof possibleResponse.data['baseMatches'] === 'object'
+      && possibleResponse.data['baseMatches'] !== null;
   } else {
     return false;
   }
@@ -103,7 +105,7 @@ export interface TrialScopeErrorResponse {
   errors: TrialScopeError[];
 }
 
-function isTrialScopeErrorResponse(o: unknown): o is TrialScopeErrorResponse {
+export function isTrialScopeErrorResponse(o: unknown): o is TrialScopeErrorResponse {
   if (typeof o !== 'object') {
     return false;
   }

--- a/src/trialscope.ts
+++ b/src/trialscope.ts
@@ -7,6 +7,7 @@ import { mapConditions } from './mapping';
 import { Bundle, Condition } from './bundle';
 import { IncomingMessage } from 'http';
 import Configuration from './env';
+import RequestError from './request-error';
 
 const environment = new Configuration().defaultEnvObject();
 
@@ -157,7 +158,7 @@ function parsePhase(phase: string): string | null {
   if (phase in TRIALSCOPE_PHASES) {
     return TRIALSCOPE_PHASES[phase];
   } else {
-    throw new Error(`Cannot parse phase: "${phase}"`);
+    throw new RequestError(`Cannot parse phase: "${phase}"`);
   }
 }
 
@@ -165,7 +166,7 @@ function parseRecruitmentStatus(status: string): string | null {
   if (status in TRIALSCOPE_STATUSES) {
     return TRIALSCOPE_STATUSES[status];
   } else {
-    throw new Error(`Cannot parse recruitment status: "${status}"`);
+    throw new RequestError(`Cannot parse recruitment status: "${status}"`);
   }
 }
 
@@ -285,6 +286,7 @@ export default runTrialScopeQuery;
 /**
  * Runs a TrialScope query.
  *
+ * @deprecated Will be merged in with #runTrialScopeQuery
  * @param {TrialScopeQuery|string} query the query to run
  */
 export function runRawTrialScopeQuery(query: TrialScopeQuery | string): Promise<TrialScopeResponse> {


### PR DESCRIPTION
This adds an exception handler to the server code to catch exceptions raised when generating the request. This should prevent the server from stopping when an exception occurs within the server.

It also removes some code that existed to allow the server to work with the old TrialScope-based version of the front end. As that version no longer exists, it removes that code rather than add an exception handler to that.