### PR TITLE
Add scores to SearchSet entries

### DIFF
--- a/spec/searchset.spec.ts
+++ b/spec/searchset.spec.ts
@@ -16,5 +16,47 @@ describe('SearchSet', () => {
     expect(searchSet.total).toEqual(1);
     expect(searchSet.entry.length).toEqual(1);
     expect(searchSet.entry[0].resource).toEqual(study);
+    expect(searchSet.entry[0].search).toBeDefined();
+    if (searchSet.entry[0].search) {
+      expect(searchSet.entry[0].search.score).toEqual(1);
+      expect(searchSet.entry[0].search.mode).toEqual('match');
+    }
+  });
+
+  describe('.addEntry', () => {
+    const researchStudy = new ResearchStudy(1);
+    let searchSet: SearchSet;
+    beforeEach(() => { searchSet = new SearchSet(); });
+    it('converts NaN to 1.0', () => {
+      searchSet.addEntry(researchStudy, Number.NaN);
+      expect(searchSet.entry.length).toEqual(1);
+      expect(searchSet.entry[0].search).toBeDefined();
+      // And prove it to TypeScript
+      if (searchSet.entry[0].search)
+        expect(searchSet.entry[0].search.score).toEqual(1);
+    });
+    it('converts negative scores to 0', () => {
+      searchSet.addEntry(researchStudy, -8);
+      expect(searchSet.entry[0].search).toBeDefined();
+      if (searchSet.entry[0].search)
+      expect(searchSet.entry[0].search.score).toEqual(0);
+    });
+    it('accepts valid scores', () => {
+      searchSet.addEntry(researchStudy, 0.25);
+      expect(searchSet.entry[0].search).toBeDefined();
+      if (searchSet.entry[0].search)
+      expect(searchSet.entry[0].search.score).toEqual(0.25);
+    });
+    it('uses the match value', () => {
+      searchSet.addEntry(researchStudy, -8, 'include');
+      expect(searchSet.entry[0].search).toBeDefined();
+      if (searchSet.entry[0].search)
+      expect(searchSet.entry[0].search.mode).toEqual('include');
+    });
+    it('updates the total', () => {
+      searchSet.total = 1;
+      searchSet.addEntry(researchStudy);
+      expect(searchSet.total).toEqual(2);
+    });
   });
 });

--- a/src/searchset.ts
+++ b/src/searchset.ts
@@ -1,8 +1,13 @@
 import { ResearchStudy } from './research-study';
 
+/**
+ * The search entry mode valueset (from https://www.hl7.org/fhir/valueset-search-entry-mode.html).
+ */
+export type SearchEntryMode = 'match' | 'include' |	'outcome';
+
 export interface SearchResult {
-  mode: string;
-  score: number;
+  mode?: string;
+  score?: number;
 }
 
 export interface SearchBundleEntry {
@@ -14,15 +19,49 @@ export class SearchSet {
   // Class attributes
   resourceType = 'Bundle';
   type = 'searchset';
+  /**
+   * The total number of results. As a bundle support pagination, this defaults
+   * to the current number of studies, but may be overridden. (See
+   * https://www.hl7.org/fhir/http.html#paging for details on paging in FHIR.)
+   * Note that addEntry will increment the total by one on each call.
+   */
   total = 0;
   entry: SearchBundleEntry[] = [];
 
-  constructor(studies: ResearchStudy[]) {
-    this.total = studies.length;
-
-    for (const study of studies) {
-      this.entry.push({ resource: study });
+  /**
+   * Creates a new SearchSet, adding the given array of studies with a default
+   * score of 1.0.
+   * @param studies the studies to add
+   */
+  constructor(studies?: ResearchStudy[]) {
+    if (studies) {
+      for (const study of studies) {
+        this.addEntry(study);
+      }
     }
+  }
+
+  /**
+   * Add a study to the searchset.
+   *
+   * If the score is less than 0, it will be set to 0. Otherwise, if it isn't
+   * a valid number, it will be set to 1.
+   *
+   * @param study the study to add
+   * @param score the score, from [0..1]
+   * @param mode the mode, defaults to 'match'
+   */
+  addEntry(study: ResearchStudy, score = 1, mode: SearchEntryMode = 'match'): void {
+    // This somewhat bizarre logic is to catch NaN
+    if (!(score > 0 && score < 1)) {
+      if (score < 0) {
+        score = 0;
+      } else {
+        score = 1;
+      }
+    }
+    this.entry.push({ resource: study, search: { mode: mode, score: score } });
+    this.total++;
   }
 }
 


### PR DESCRIPTION
Adds scores to the entries within the SearchSet created.

Note that at present, you can't add the scores when you create the SearchSet, you have to add them each individually with individual calls to `addEntry`. I'm not certain it's worth letting you pre-map them at creation time as the constructor currently uses `addEntry` to generate the entries anyway, and you'd essentially be doing a bunch of extra work rather than just calling `addEntry` yourself.