### PR TITLE
Update ClinicalTrials.gov based on BreastCancerTrials.org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -449,11 +449,14 @@
         "@types/superagent": "*"
       }
     },
-    "@types/xml2json": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@types/xml2json/-/xml2json-0.11.0.tgz",
-      "integrity": "sha512-7q/z45tcMKEPlbCoV5EGPdFLrHst9m3w/sy1tdCvfoR2gI78UgzfhML2jemKAuE2bY2/ZE7f0qzWM0LZ97M54Q==",
-      "dev": true
+    "@types/xml2js": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
+      "integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yauzl": {
       "version": "2.9.1",
@@ -775,14 +778,6 @@
             "kind-of": "^6.0.2"
           }
         }
-      }
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "body-parser": {
@@ -1699,11 +1694,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -1973,11 +1963,6 @@
         "type-fest": "^0.8.0"
       }
     },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2197,14 +2182,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "requires": {
-        "punycode": "2.x.x"
-      }
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2365,23 +2342,6 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.6.0.tgz",
       "integrity": "sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw==",
       "dev": true
-    },
-    "joi": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
-      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
-      "requires": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
-        }
-      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2623,11 +2583,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -2685,15 +2640,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
-      }
-    },
-    "node-expat": {
-      "version": "2.3.18",
-      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.3.18.tgz",
-      "integrity": "sha512-9dIrDxXePa9HSn+hhlAg1wXkvqOjxefEbMclGxk2cEnq/Y3U7Qo5HNNqeo3fQ4bVmLhcdt3YN1TZy7WMZy4MHw==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.13.2"
       }
     },
     "node-preload": {
@@ -3010,7 +2956,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.7.0",
@@ -3151,6 +3098,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "7.3.2",
@@ -3672,21 +3624,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
-    "topo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "requires": {
-        "hoek": "6.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
-        }
-      }
-    },
     "ts-node": {
       "version": "8.10.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
@@ -3968,15 +3905,19 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "xml2json": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.12.0.tgz",
-      "integrity": "sha512-EPJHRWJnJUYbJlzR4pBhZODwWdi2IaYGtDdteJi0JpZ4OD31IplWALuit8r73dJuM4iHZdDVKY1tLqY2UICejg==",
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
       "requires": {
-        "hoek": "^4.2.1",
-        "joi": "^13.1.2",
-        "node-expat": "^2.3.18"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
       }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "extract-zip": "^2.0.1",
-    "xml2json": "^0.12.0"
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
@@ -34,7 +34,7 @@
     "@types/jasmine": "^3.5.10",
     "@types/node": "^14.0.13",
     "@types/supertest": "^2.0.9",
-    "@types/xml2json": "^0.11.0",
+    "@types/xml2js": "^0.4.5",
     "@typescript-eslint/eslint-plugin": "^3.7.1",
     "@typescript-eslint/parser": "^3.7.1",
     "eslint": "^7.5.0",

--- a/spec/clinicaltrialgov.spec.ts
+++ b/spec/clinicaltrialgov.spec.ts
@@ -243,7 +243,7 @@ describe('ClinicalTrialGovService', () => {
       // "Import" the trial
       await downloader.extractResults(fs.createReadStream(specFilePath('search_result.zip')));
       // Note this mutates study, which doesn't actually matter at present.
-      updatedTrial = await downloader.updateTrial(study);
+      updatedTrial = await downloader.updateResearchStudy(study);
     });
 
     it('fills in inclusion criteria', () => {
@@ -275,13 +275,13 @@ describe('ClinicalTrialGovService', () => {
     it('returns same object on empty study', () => {
       const empty = new ResearchStudyObj(2);
       const backup_service = new ctg.ClinicalTrialGovService(tempDataDirPath);
-      return expectAsync(backup_service.updateTrial(empty)).toBeResolvedTo(empty);
+      return expectAsync(backup_service.updateResearchStudy(empty)).toBeResolvedTo(empty);
     });
 
     it('returns on filled out study', () => {
       const study_filled = trialFilled as ResearchStudy;
       const backup_service = new ctg.ClinicalTrialGovService(tempDataDirPath);
-      expect(backup_service.updateTrial(study_filled)).toBeDefined();
+      expect(backup_service.updateResearchStudy(study_filled)).toBeDefined();
     });
   });
 

--- a/spec/clinicaltrialgov.spec.ts
+++ b/spec/clinicaltrialgov.spec.ts
@@ -242,7 +242,7 @@ describe('ClinicalTrialGovService', () => {
       // "Import" the trial
       await downloader.extractResults(fs.createReadStream(specFilePath('search_result.zip')));
       // Note this mutates study, which doesn't actually matter at present.
-      updatedTrial = downloader.updateTrial(study);
+      updatedTrial = await downloader.updateTrial(study);
     });
 
     it('fills in inclusion criteria', () => {
@@ -274,7 +274,7 @@ describe('ClinicalTrialGovService', () => {
     it('returns same object on empty study', () => {
       const empty = new ResearchStudyObj(2);
       const backup_service = new ctg.ClinicalTrialGovService(tempDataDirPath);
-      expect(backup_service.updateTrial(empty)).toBe(empty);
+      return expectAsync(backup_service.updateTrial(empty)).toBeResolvedTo(empty);
     });
 
     it('returns on filled out study', () => {

--- a/spec/clinicaltrialgov.spec.ts
+++ b/spec/clinicaltrialgov.spec.ts
@@ -239,6 +239,7 @@ describe('ClinicalTrialGovService', () => {
     let updatedTrial: ResearchStudy;
     beforeAll(async function () {
       downloader = new ctg.ClinicalTrialGovService(tempDataDirPath);
+      await downloader.init();
       // "Import" the trial
       await downloader.extractResults(fs.createReadStream(specFilePath('search_result.zip')));
       // Note this mutates study, which doesn't actually matter at present.

--- a/spec/research-study.spec.ts
+++ b/spec/research-study.spec.ts
@@ -1,6 +1,7 @@
 import ResearchStudy, {
   convertStringArrayToCodeableConcept,
-  createReferenceTo
+  createReferenceTo,
+  getContainedResource
 } from '../src/research-study';
 import { BaseResource,
   ContactDetail,
@@ -36,6 +37,32 @@ describe('createReferenceTo', () => {
     const resource: BaseResource = { } as BaseResource;
     expect(() => { createReferenceTo(resource) }).toThrowError('no ID to create reference');
   });
+});
+
+describe('.getContainedResource', () => {
+  it('returns null if the contained list is empty', () => {
+    expect(getContainedResource({ resourceType: 'ResearchStudy' }, 'anything')).toBeNull();
+  });
+  it('returns null if the contained list does not contain a resource with the given ID', () => {
+    expect(getContainedResource({
+      resourceType: 'ResearchStudy',
+      contained: [
+        { resourceType: 'Location', id: 'foo' }
+      ]
+    }, 'bar')).toBeNull();
+  });
+  it('returns the proper object', () => {
+    const expected: Group = { resourceType: 'Group', id: 'group' };
+    expect(getContainedResource({
+      resourceType: 'ResearchStudy',
+      contained: [
+        { resourceType: 'Location', id: 'location' },
+        { resourceType: 'Organization', id: 'organization' },
+        expected,
+        { resourceType: 'Practitioner', id: 'practitioner' }
+      ]
+    }, 'group')).toEqual(expected);
+  })
 });
 
 describe('ResearchStudy', () => {

--- a/src/clinicalstudy.ts
+++ b/src/clinicalstudy.ts
@@ -7,13 +7,14 @@
  */
 
 /**
- * For documentation purposes, indicates an element that will only ever appear once in a valid document. It's still
- * ultimately an array at present.
+ * For documentation purposes, indicates an element that will only ever appear once in a valid document. It's
+ * implmented as a TypeScript tuple with a single element, which matches how xml2js will ultimately parse the XML.
  */
-type One<T> = Array<T>;
+type One<T> = [ T ];
 
 /**
- * For documentation purposes, indicates an element that can appear any number of times.
+ * For documentation purposes, indicates an element that can appear any number of times. (Conceptually, an empty array
+ * isn't actually valid for these types.)
  */
 type Unbounded<T> = Array<T>;
 
@@ -434,7 +435,7 @@ export type PhaseEnum =
 export type BiospecRetentionEnum = 'None Retained' | 'Samples With DNA' | 'Samples Without DNA';
 
 export interface ClinicalStudy {
-  $: { rank?: string };
+  $?: { rank?: string };
   required_header: One<RequiredHeaderStruct>;
   id_info: One<IdInfoStruct>;
   brief_title: One<string>;

--- a/src/clinicalstudy.ts
+++ b/src/clinicalstudy.ts
@@ -1,0 +1,503 @@
+/**
+ * Types related to the ClinicalTrials.gov XML file. This is based on the ClinicalTrials.gov XML schema:
+ * https://clinicaltrials.gov/ct2/html/images/info/public.xsd
+ *
+ * This is a *partial* set of types. It's based on the object that would be created via xml2js, assuming that the
+ * given XML file is valid.
+ */
+
+/**
+ * For documentation purposes, indicates an element that will only ever appear once in a valid document. It's still
+ * ultimately an array at present.
+ */
+type One<T> = Array<T>;
+
+/**
+ * For documentation purposes, indicates an element that can appear any number of times.
+ */
+type Unbounded<T> = Array<T>;
+
+/**
+ * For documentation purposes, a field that is an XML Schema Integer.
+ * (Note that technically, integer is unbounded - that is, may be any integer of any length.)
+ */
+export type XSInteger = string;
+
+/**
+ * For documentation purposes, a field that is an XML Schema positiveInteger.
+ */
+export type XSPositiveInteger = string;
+
+// Generic data types
+
+export type ActualEnum = 'Actual' | 'Anticipated' | 'Estimate';
+
+// This is how it exists within the XML. It could be converted to a boolean.
+export type YesNoEnum = 'Yes' | 'No';
+
+/**
+ * Actually needs to match a pattern, but TypeScript doesn't support that. From
+ * the schema:
+ *
+ * Dates may now include a day
+ *     Month Day, Year    Or    Month Year
+ * Necessary to accurately calculate deadlines
+ *
+ * The pattern is: (Unknown|((January|February|March|April|May|June|July|August|September|October|November|December) (([12]?[0-9]|30|31)\, )?[12][0-9]
+ */
+export type VariableDate = string;
+
+// Due to the way the parser works
+export type VariableDateStruct =
+  | {
+      $: { type?: ActualEnum };
+      _: VariableDate;
+    }
+  | VariableDate;
+
+// Required Header
+
+export interface RequiredHeaderStruct {
+  download_date: One<string>;
+  link_text: One<string>;
+  url: One<string>;
+}
+
+// Id Info
+
+export interface IdInfoStruct {
+  org_study_id?: One<string>;
+  secondary_id?: Unbounded<string>;
+  nct_id: One<string>;
+  nct_alias?: Unbounded<string>;
+}
+
+// Sponsor
+
+export type AgencyClassEnum = 'NIH' | 'U.S. Fed' | 'Industry' | 'Other';
+
+export interface SponsorStruct {
+  agency: One<string>;
+  agency_class?: One<AgencyClassEnum>;
+}
+
+// Sponsors
+
+export interface SponsorsStruct {
+  lead_sponsor: One<SponsorStruct>;
+  collaborator?: Unbounded<SponsorStruct>;
+}
+
+// Oversight
+
+export interface OversightInfoStruct {
+  has_dmc?: One<YesNoEnum>;
+  is_fda_regulated_drug?: One<YesNoEnum>;
+  is_fda_regulated_device?: One<YesNoEnum>;
+  is_unapproved_device?: One<YesNoEnum>;
+  is_ppsd?: One<YesNoEnum>;
+  is_us_export?: One<YesNoEnum>;
+}
+
+// Expanded Access
+
+export interface ExpandedAccessInfoStruct {
+  expanded_access_type_individual?: One<YesNoEnum>;
+  expanded_access_type_intermediate?: One<YesNoEnum>;
+  expanded_access_type_treatment?: One<YesNoEnum>;
+}
+
+// Study Design
+
+export interface StudyDesignInfoStruct {
+  allocation?: One<string>;
+  intervention_model?: One<string>;
+  intervention_model_description?: One<string>;
+  primary_purpose?: One<string>;
+  observational_model?: One<string>;
+  time_perspective?: One<string>;
+  masking?: One<string>;
+  masking_description?: One<string>;
+}
+
+// Protocol Outcome
+
+export interface protocol_outcome_struct {
+  measure: One<string>;
+  time_frame?: One<string>;
+  description?: One<string>;
+}
+
+// Enrollment
+
+export type EnrollmentStruct =
+  | {
+      $: { type: ActualEnum };
+      _: XSInteger;
+    }
+  | XSInteger;
+
+// Arm Group
+
+export interface ArmGroupStruct {
+  arm_group_label: One<string>;
+  arm_group_type?: One<string>;
+  description?: One<string>;
+}
+
+// Intervention
+
+export type InterventionTypeEnum =
+  | 'Behavioral'
+  | 'Biological'
+  | 'Combination Product'
+  | 'Device'
+  | 'Diagnostic Test'
+  | 'Dietary Supplement'
+  | 'Drug'
+  | 'Genetic'
+  | 'Procedure'
+  | 'Radiation'
+  | 'Other';
+
+export interface InterventionStruct {
+  intervention_type: One<InterventionTypeEnum>;
+  intervention_name: One<string>;
+  description?: One<string>;
+  arm_group_label?: Unbounded<string>;
+  other_name?: Unbounded<string>; // synonyms for intervention_name
+}
+
+// Textblock
+
+export interface TextblockStruct {
+  textblock: One<string>;
+}
+
+// Eligibility
+
+export type SamplingMethodEnum = 'Probability Sample' | 'Non-Probability Sample';
+
+export type GenderEnum = 'Female' | 'Male' | 'All';
+
+/**
+ * This is another XML schema pattern. The pattern is:
+ * N/A|([1-9][0-9]* (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes))
+ */
+export type AgePattern = string;
+
+export interface EligibilityStruct {
+  study_pop?: One<TextblockStruct>;
+  sampling_method?: One<SamplingMethodEnum>;
+  criteria?: One<TextblockStruct>;
+  gender: One<GenderEnum>;
+  gender_based?: One<YesNoEnum>;
+  gender_description?: One<string>;
+  minimum_age: One<AgePattern>;
+  maximum_age: One<AgePattern>;
+  healthy_volunteers?: One<string>;
+}
+
+// Contact
+
+export interface ContactStruct {
+  first_name?: One<string>;
+  middle_name?: One<string>;
+  last_name?: One<string>;
+  degrees?: One<string>;
+  phone?: One<string>;
+  phone_ext?: One<string>;
+  email?: One<string>;
+}
+
+// Investigator
+
+export type RoleEnum = 'Principal Investigator' | 'Sub-Investigator' | 'Study Chair' | 'Study Director';
+
+export interface InvestigatorStruct {
+  first_name?: One<string>;
+  middle_name?: One<string>;
+  last_name: One<string>;
+  degrees?: One<string>;
+  role?: One<RoleEnum>;
+  affiliation?: One<string>;
+}
+
+// Address
+
+export interface AddressStruct {
+  city: One<string>;
+  state?: One<string>;
+  zip?: One<string>;
+  country: One<string>;
+}
+
+// Facility
+export interface FacilityStruct {
+  name?: One<string>;
+  address?: One<AddressStruct>;
+}
+
+// Status
+export type RecruitmentStatusEnum =
+  | 'Active, not recruiting'
+  | 'Completed'
+  | 'Enrolling by invitation'
+  | 'Not yet recruiting'
+  | 'Recruiting'
+  | 'Suspended'
+  | 'Terminated'
+  | 'Withdrawn';
+
+export type ExpandedAccessStatusEnum =
+  | 'Available'
+  | 'No longer available'
+  | 'Temporarily not available'
+  | 'Approved for marketing';
+
+export type RedactedRecordStatusEnum = 'Withheld';
+
+export type UnknownStatusEnum = 'Unknown status';
+
+/**
+ * Valid values for overall status depend on the value of the study type:
+ *  - For studies that have not been updated in 2 years, the value unknown_status_enum
+ *  - For Interventional or Observational studies, values from recruitment_status_enum
+ *  - For Expanded Access studies, values from expanded_access_status_enum
+ *  - Otherwise, values from redacted_record_status_enum
+ *
+ * This enum is also the valid values for location status, but the rules for which
+ * locations are included or witheld in the public xml are subject to change.
+ * You may not see all possible values.
+ */
+export type StatusEnum =
+  | RecruitmentStatusEnum
+  | ExpandedAccessStatusEnum
+  | RedactedRecordStatusEnum
+  | UnknownStatusEnum;
+
+// Location
+
+export interface LocationStruct {
+  facility?: One<FacilityStruct>;
+  status?: One<StatusEnum>;
+  contact?: One<ContactStruct>;
+  contact_backup?: One<ContactStruct>;
+  investigator?: Unbounded<InvestigatorStruct>;
+}
+
+// Location Countries
+
+export interface CountriesStruct {
+  country?: Unbounded<string>;
+}
+
+// Links
+
+export interface LinkStruct {
+  url: One<string>;
+  description?: One<string>;
+}
+
+// References
+
+export interface ReferenceStruct {
+  citation?: One<string>;
+  PMID?: One<XSPositiveInteger>;
+}
+
+// Responsible Party
+
+export type ResponsiblePartyTypeEnum = 'Sponsor' | 'Principal Investigator' | 'Sponsor-Investigator';
+
+/**
+ * old style
+ */
+export interface ResponsiblePartyStructOldStyle {
+  name_title?: One<string>;
+  organization?: One<string>;
+}
+
+/**
+ * new style, used in newer records
+ */
+export interface ResponsiblePartyStructNewStyle {
+  responsible_party_type: One<ResponsiblePartyTypeEnum>;
+  investigator_affiliation?: One<string>;
+  investigator_full_name?: One<string>;
+  investigator_title?: One<string>;
+}
+
+export type ResponsiblePartyStruct = ResponsiblePartyStructOldStyle | ResponsiblePartyStructNewStyle;
+
+// Browse
+
+export interface BrowseStruct {
+  mesh_term?: Unbounded<string>;
+}
+
+// Patient Data
+
+export interface PatientDataStruct {
+  sharing_ipd: One<string>;
+  ipd_description?: One<string>;
+  ipd_info_type?: Unbounded<string>;
+  ipd_time_frame?: One<string>;
+  ipd_access_criteria?: One<string>;
+  ipd_url?: One<string>;
+}
+
+// Study Docs
+
+export interface StudyDocStruct {
+  doc_id?: One<string>;
+  doc_type?: One<string>;
+  doc_url?: One<string>;
+  doc_comment?: One<string>;
+}
+
+export interface StudyDocsStruct {
+  study_doc: Unbounded<StudyDocStruct>;
+}
+
+// Provided Document Section Struct
+
+export interface provided_document_struct {
+  document_type?: One<string>;
+  document_has_protocol?: One<string>;
+  document_has_icf: One<string>;
+  document_has_sap?: One<string>;
+  document_date?: One<string>;
+  document_url?: One<string>;
+}
+
+export interface provided_document_section_struct {
+  provided_document: provided_document_struct; //  maxOccurs="unbounded"
+}
+
+// Pending Results
+
+// The schema declaration here is weird, and probably wrong. It defines an
+// optional unbounded choice between three different elements that are each
+// individually optional.
+//
+// In regex terms, it's doing something like (a?|b?|c?)*.
+export interface PendingResultsStruct {
+  submitted?: VariableDateStruct[];
+  returned?: VariableDateStruct[];
+  submission_canceled?: VariableDateStruct[];
+}
+
+// Group
+
+export interface GroupStruct {
+  $: { group_id: string };
+  title?: One<string>;
+  description?: One<string>;
+}
+
+export interface ParticipantsStruct {
+  $: {
+    group_id: string;
+    count?: string;
+  };
+  _: string;
+}
+
+// Milestone
+export interface MilestoneStruct {
+  title: One<string>;
+  participants_list: One<{
+    participants: ParticipantsStruct[];
+  }>;
+}
+
+// Clinical Study
+
+export type StudyTypeEnum =
+  | 'Expanded Access'
+  | 'Interventional'
+  | 'N/A'
+  | 'Observational'
+  | 'Observational [Patient Registry]';
+
+export type PhaseEnum =
+  | 'N/A'
+  | 'Early Phase 1'
+  | 'Phase 1'
+  | 'Phase 1/Phase 2'
+  | 'Phase 2'
+  | 'Phase 2/Phase 3'
+  | 'Phase 3'
+  | 'Phase 4';
+
+export type BiospecRetentionEnum = 'None Retained' | 'Samples With DNA' | 'Samples Without DNA';
+
+export interface ClinicalStudy {
+  $: { rank?: string };
+  required_header: One<RequiredHeaderStruct>;
+  id_info: One<IdInfoStruct>;
+  brief_title: One<string>;
+  acronym?: One<string>;
+  official_title?: One<string>;
+  sponsors: One<SponsorsStruct>;
+  source: One<string>;
+  oversight_info?: One<OversightInfoStruct>;
+  brief_summary?: One<TextblockStruct>;
+  detailed_description?: One<TextblockStruct>;
+  overall_status: One<StatusEnum>;
+  last_known_status?: One<StatusEnum>;
+  why_stopped?: One<string>;
+  start_date?: One<VariableDateStruct>;
+  completion_date?: One<VariableDateStruct>;
+  primary_completion_date?: One<VariableDateStruct>;
+  phase?: One<PhaseEnum>;
+  study_type: One<StudyTypeEnum>;
+  has_expanded_access?: One<YesNoEnum>;
+  expanded_access_info?: One<ExpandedAccessInfoStruct>;
+  study_design_info?: One<StudyDesignInfoStruct>;
+  target_duration?: One<string>;
+  // primary_outcome?: Unbounded<ProtocolOutcomeStruct>;
+  // secondary_outcome?: Unbounded<ProtocolOutcomeStruct>;
+  // other_outcome?: Unbounded<ProtocolOutcomeStruct>;
+  number_of_arms?: One<XSInteger>;
+  number_of_groups?: One<XSInteger>;
+  enrollment?: One<EnrollmentStruct>;
+  condition?: Unbounded<string>;
+  // arm_group: arm_group_struct; //  minOccurs="0" maxOccurs="unbounded"
+  // intervention: intervention_struct; //  minOccurs="0" maxOccurs="unbounded"
+  // biospec_retention: biospec_retention_enum; //  minOccurs="0"
+  // biospec_descr: textblock_struct; //  minOccurs="0"
+  eligibility?: One<EligibilityStruct>; //  minOccurs="0"
+  // overall_official: investigator_struct; //  minOccurs="0" maxOccurs="unbounded"
+  // overall_contact: contact_struct; //  minOccurs="0"
+  // overall_contact_backup: contact_struct; //  minOccurs="0"
+  location?: Unbounded<LocationStruct>;
+  // location_countries: countries_struct; //  minOccurs="0"
+  // removed_countries: countries_struct; //  minOccurs="0"
+  // link: link_struct; //  minOccurs="0" maxOccurs="unbounded"
+  // reference: reference_struct; //  minOccurs="0" maxOccurs="unbounded"
+  // results_reference: reference_struct; //  minOccurs="0" maxOccurs="unbounded"
+  // verification_date: variable_date_type; //  minOccurs="0"
+  // study_first_submitted: variable_date_type; //  minOccurs="0"
+  // study_first_submitted_qc: variable_date_type; //  minOccurs="0"
+  // study_first_posted: variable_date_struct; //  minOccurs="0"
+  // results_first_submitted: variable_date_type; //  minOccurs="0"
+  // results_first_submitted_qc: variable_date_type; //  minOccurs="0"
+  // results_first_posted: variable_date_struct; //  minOccurs="0"
+  // disposition_first_submitted: variable_date_type; //  minOccurs="0"
+  // disposition_first_submitted_qc: variable_date_type; //  minOccurs="0"
+  // disposition_first_posted: variable_date_struct; //  minOccurs="0"
+  // last_update_submitted: variable_date_type; //  minOccurs="0"
+  // last_update_submitted_qc: variable_date_type; //  minOccurs="0"
+  // last_update_posted: variable_date_struct; //  minOccurs="0"
+  // responsible_party: responsible_party_struct; //  minOccurs="0"
+  // keyword: xs:string; //  minOccurs="0" maxOccurs="unbounded"
+  // condition_browse: browse_struct; //  minOccurs="0"
+  // intervention_browse: browse_struct; //  minOccurs="0"
+  // patient_data: patient_data_struct; //  minOccurs="0"
+  // study_docs: study_docs_struct; //  minOccurs="0"
+  // provided_document_section: provided_document_section_struct; //  minOccurs="0"
+  // pending_results: pending_results_struct; //  minOccurs="0"
+  // clinical_results: clinical_results_struct; //  minOccurs="0"
+}

--- a/src/clinicaltrialgov.ts
+++ b/src/clinicaltrialgov.ts
@@ -181,7 +181,10 @@ export class ClinicalTrialGovService {
 
   getDownloadedTrial(nctId: string): Promise<ClinicalStudy> {
     const filePath = `${this.dataDir}/backups/${nctId}.xml`;
-    // TODO: Catch the file not existing.
+    // TODO: Catch the file not existing. This should probably be handled
+    // specially, such as by returns null or something else to differentiate
+    // it from other errors, since an file not existing may mean it simply
+    // needs to be loaded later
     return new Promise((resolve, reject) => {
       fs.readFile(filePath, { encoding: 'utf8' }, (error, data): void => {
         if (error) {
@@ -217,7 +220,16 @@ export function createClinicalTrialGovService(dataDir: string): Promise<Clinical
   });
 }
 
-export function updateResearchStudyWithClinicalStudy(result: ResearchStudy, study: ClinicalStudy): ResearchStudy {
+/**
+ * Updates a research study with data from a clinical study off the ClinicalTrials.gov website. This will only update
+ * fields that do not have data, it will not overwrite any existing data.
+ *
+ * @param result the research study to update
+ * @param study the clinical study to use to update (this takes a partial as the ClinicalStudy type describes the XML
+ * as the schema defines it, so this is designed to handle invalid XML that's missing information that should be
+ * required)
+ */
+export function updateResearchStudyWithClinicalStudy(result: ResearchStudy, study: Partial<ClinicalStudy>): ResearchStudy {
   if (!result.enrollment) {
     const eligibility = study.eligibility;
     if (eligibility) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from './searchset';
 export * from './clinicaltrialgov';
 
 // The export { v } from "mod" forms do not appear to work yet
+import { ClinicalStudy } from './clinicalstudy';
 import RequestError from './request-error';
 import ClinicalTrialMatchingService, { ClinicalTrialMatcher, Configuration } from './server';
 
@@ -17,6 +18,7 @@ export * from './env';
 
 export default ClinicalTrialMatchingService;
 export {
+  ClinicalStudy,
   ClinicalTrialMatcher,
   ClinicalTrialMatchingService,
   Configuration as ServiceConfiguration,

--- a/src/research-study.ts
+++ b/src/research-study.ts
@@ -44,6 +44,13 @@ export function addToContainer<TContainer, TContained, K extends keyof TContaine
   (container[propertyName] as Array<TContained>).push(item);
 }
 
+export function addContainedResource(researchStudy: IResearchStudy, resource: ContainedResource): Reference {
+  if (!researchStudy.contained)
+    researchStudy.contained = [];
+  researchStudy.contained.push(resource);
+  return createReferenceTo(resource);
+}
+
 /**
  * Creates a Reference to a resource, assuming it will be a contained resource.
  * The resource must have an `id` set on it, otherwise this will raise an error.

--- a/src/research-study.ts
+++ b/src/research-study.ts
@@ -52,6 +52,25 @@ export function addContainedResource(researchStudy: IResearchStudy, resource: Co
 }
 
 /**
+ * Looks up a contained resource by ID. This works by scanning through every contained resource in the research study,
+ * so it ultimately operates in O(n) time! If you need to continually look up references, it's recommended that to
+ * instead create a Map<string, ContainedResource> to look them up.
+ * @param id the ID of the resource to look up
+ */
+export function getContainedResource(researchStudy: IResearchStudy, id: string): ContainedResource | null {
+ if (researchStudy.contained) {
+   // Lookup has to be done sequentially for now
+   for (const contained of researchStudy.contained) {
+     if (contained.id === id) {
+       return contained;
+     }
+   }
+ }
+ // Contained empty/nothing found? Return null.
+ return null;
+}
+
+/**
  * Creates a Reference to a resource, assuming it will be a contained resource.
  * The resource must have an `id` set on it, otherwise this will raise an error.
  * @param resource the resource to create a Reference to


### PR DESCRIPTION
This updates the backup service based on changes that were made in the BreastCancerTrials.org service wrapper. It also changes the XML parser used to one that has a well-documented output, and updates the ClinicalStudy type used to be more complete based on the ClinicalTrials.gov schema.