### PR TITLE
Rename and better document convertToCodeableConcept utility

### DIFF
--- a/spec/research-study.spec.ts
+++ b/spec/research-study.spec.ts
@@ -1,5 +1,5 @@
 import ResearchStudy, {
-  convertStringArrayToCodeableConcept,
+  convertStringsToCodeableConcept,
   createReferenceTo,
   getContainedResource
 } from '../src/research-study';
@@ -10,10 +10,25 @@ import { BaseResource,
   Location
 } from '../src/fhir-types';
 
-describe('convertStringArrayToCodeableConcept', () => {
-  it('converts to codeable concepts', () => {
-    expect(convertStringArrayToCodeableConcept('["a","b","c"]')).toEqual([
+describe('convertStringsToCodeableConcept', () => {
+  it('converts JSON to codeable concepts', () => {
+    expect(convertStringsToCodeableConcept('["a","b","c"]')).toEqual([
       { text: 'a' }, { text: 'b' }, { text: 'c' }
+    ]);
+  });
+  it('converts CSV to codeable concepts', () => {
+    expect(convertStringsToCodeableConcept('a, b ,c')).toEqual([
+      { text: 'a' }, { text: 'b' }, { text: 'c' }
+    ]);
+  });
+  it('converts a single string a codeable concept', () => {
+    expect(convertStringsToCodeableConcept('test')).toEqual([
+      { text: 'test' }
+    ]);
+  });
+  it('converts an array to codeable concepts', () => {
+    expect(convertStringsToCodeableConcept(['foo', 'bar', 'baz'])).toEqual([
+      { text: 'foo' }, { text: 'bar' }, { text: 'baz' }
     ]);
   });
 });

--- a/src/research-study.ts
+++ b/src/research-study.ts
@@ -17,11 +17,22 @@ import {
 
 /**
  * Utility function to convert a list of strings into a list of CodeableConcepts.
+ * If given a string that "looks like" it's a JSON array (starts and ends with '[' ']') this will attempt to parse the
+ * list as JSON. (If the JSON is invalid, the exception from JSON.parse will be propegated.) Otherwise, if the
+ * conditions is a string, it will be split on commas.
  *
  * @param conditions a list of strings to convert to CodeableConcepts
  */
-export function convertStringArrayToCodeableConcept(conditions: string): CodeableConcept[] {
-  const jsonConditions: string[] = JSON.parse(conditions) as string[];
+export function convertStringsToCodeableConcept(conditions: string | string[]): CodeableConcept[] {
+  if (typeof conditions === 'string') {
+    if (conditions.startsWith('[') && conditions.endsWith(']')) {
+      conditions = JSON.parse(conditions);
+    }
+  }
+  if (!Array.isArray(conditions)) {
+    conditions = conditions.split(/\s*,\s*/);
+  }
+  const jsonConditions: string[] = conditions;
   const fhirConditions: CodeableConcept[] = [];
   for (const condition of jsonConditions) {
     fhirConditions.push({ text: condition });


### PR DESCRIPTION
The `convertStringArrayToCodeableConcept` sort of lied - it expected the array to be in JSON. This changes the method to `convertStringsToCodeableConcept` and does the same thing, as well as updating the doc comment to make it clearer what it's actually doing.