### PR TITLE
Update SearchSet API and the CT.gov backup implementation

### DIFF
--- a/spec/searchset.spec.ts
+++ b/spec/searchset.spec.ts
@@ -32,16 +32,27 @@ describe('SearchSet', () => {
       expect(searchSet.entry.length).toEqual(1);
       expect(searchSet.entry[0].search).toBeDefined();
       // And prove it to TypeScript
-      if (searchSet.entry[0].search)
+      if (searchSet.entry[0].search) {
         expect(searchSet.entry[0].search.score).not.toBeDefined();
+        expect(searchSet.entry[0].search.mode).toEqual('match');
+      }
+      // Also try with a specific mode
+      searchSet.addEntry(researchStudy, 'include');
+      expect(searchSet.entry.length).toEqual(2);
+      expect(searchSet.entry[1].search).toBeDefined();
+      // And prove it to TypeScript
+      if (searchSet.entry[1].search) {
+        expect(searchSet.entry[1].search.score).not.toBeDefined();
+        expect(searchSet.entry[1].search.mode).toEqual('include');
+      }
     });
-    it('converts NaN to 1.0', () => {
+    it('does not set a score if the score is NaN', () => {
       searchSet.addEntry(researchStudy, Number.NaN);
       expect(searchSet.entry.length).toEqual(1);
       expect(searchSet.entry[0].search).toBeDefined();
       // And prove it to TypeScript
       if (searchSet.entry[0].search)
-        expect(searchSet.entry[0].search.score).toEqual(1);
+        expect(searchSet.entry[0].search.score).not.toBeDefined();
     });
     it('converts negative scores to 0', () => {
       searchSet.addEntry(researchStudy, -8);

--- a/spec/searchset.spec.ts
+++ b/spec/searchset.spec.ts
@@ -18,7 +18,7 @@ describe('SearchSet', () => {
     expect(searchSet.entry[0].resource).toEqual(study);
     expect(searchSet.entry[0].search).toBeDefined();
     if (searchSet.entry[0].search) {
-      expect(searchSet.entry[0].search.score).toEqual(1);
+      expect(searchSet.entry[0].search.score).not.toBeDefined();
       expect(searchSet.entry[0].search.mode).toEqual('match');
     }
   });
@@ -27,6 +27,14 @@ describe('SearchSet', () => {
     const researchStudy = new ResearchStudy(1);
     let searchSet: SearchSet;
     beforeEach(() => { searchSet = new SearchSet(); });
+    it('does not add a score if none is given', () => {
+      searchSet.addEntry(researchStudy);
+      expect(searchSet.entry.length).toEqual(1);
+      expect(searchSet.entry[0].search).toBeDefined();
+      // And prove it to TypeScript
+      if (searchSet.entry[0].search)
+        expect(searchSet.entry[0].search.score).not.toBeDefined();
+    });
     it('converts NaN to 1.0', () => {
       searchSet.addEntry(researchStudy, Number.NaN);
       expect(searchSet.entry.length).toEqual(1);

--- a/src/clinicaltrialgov.ts
+++ b/src/clinicaltrialgov.ts
@@ -336,7 +336,21 @@ export function updateResearchStudyWithClinicalStudy(
       let index = 0;
       for (const location of study.location) {
         const fhirLocation: Location = { resourceType: 'Location', id: 'location-' + index++ };
-        if (location.facility && location.facility[0].name) fhirLocation.name = location.facility[0].name[0];
+        if (location.facility) {
+          if (location.facility[0].name)
+            fhirLocation.name = location.facility[0].name[0];
+          if (location.facility[0].address) {
+            // Also add the address information
+            const address = location.facility[0].address[0];
+            fhirLocation.address = { use: 'work', city: address.city[0], country: address.country[0] };
+            if (address.state) {
+              fhirLocation.address.state = address.state[0];
+            }
+            if (address.zip) {
+              fhirLocation.address.postalCode = address.zip[0];
+            }
+          }
+        }
         if (location.contact) {
           const contact = location.contact[0];
           if (contact.email) {

--- a/src/searchset.ts
+++ b/src/searchset.ts
@@ -46,36 +46,53 @@ export class SearchSet implements SearchSetBundle {
   }
 
   /**
+   * Add a study to the searchset with no defined score and the search mode set
+   * to "match".
+   *
+   * @param study the study to add
+   */
+  addEntry(entry: SearchBundleEntry): void;
+  /**
+   * Add a study to the searchset with no score and the given search mode
+   *
+   * @param study the study to add
+   * @param mode the mode
+   */
+  addEntry(study: ResearchStudy, mode: SearchEntryMode): void;
+  /**
    * Add a study to the searchset.
    *
-   * If the score is less than 0, it will be set to 0. Otherwise, if it isn't
-   * a valid number, it will be set to 1.
+   * If the score is not given, then the score will be left unset in the entry.
+   * Otherwise, if the score will be clamped to the range [0..1] (values less
+   * than 0 become 0, values greater than 1 become 1). NaN is treated as
+   * "undefined" and leaves the score unset.
    *
    * @param study the study to add
    * @param score the score, from [0..1]
    * @param mode the mode, defaults to 'match'
    */
-  addEntry(entry: SearchBundleEntry): void;
   addEntry(study: ResearchStudy, score?: number, mode?: SearchEntryMode): void;
   // This overload is sort of implied, but TypeScript needs us to give it outright
   addEntry(studyOrEntry: SearchBundleEntry | ResearchStudy): void;
-  addEntry(studyOrEntry: SearchBundleEntry | ResearchStudy, score: number | null = null, mode: SearchEntryMode = 'match'): void {
+  addEntry(studyOrEntry: SearchBundleEntry | ResearchStudy, scoreOrMode: SearchEntryMode | number | null = null, mode?: SearchEntryMode): void {
+    let score = null;
+    if (typeof scoreOrMode === 'string') {
+      // There is no overload that allows two modes so if anyone did that they
+      // did it outside of TypeScript so go ahead and ignore them
+      mode = scoreOrMode;
+    } else if (typeof scoreOrMode === 'number') {
+      score = scoreOrMode;
+    }
     const entry: SearchBundleEntry = isResearchStudy(studyOrEntry)
-      ? { resource: studyOrEntry, search: { mode: mode } }
+      ? { resource: studyOrEntry, search: { mode: mode ?? 'match' } }
       : studyOrEntry;
     // Grab the score out of the entry if one was given
+    // (See above on how there is no overload for both giving an entry and a
+    // score - if you do that, you're ignoring TypeScript anyway)
     if (entry.search.score) score = entry.search.score;
-    if (score !== null) {
-      // This somewhat bizarre logic is to catch NaN
-      if (!(score >= 0 && score <= 1)) {
-        if (score < 0) {
-          score = 0;
-        } else {
-          score = 1;
-        }
-      }
-      // Now that we've made score valid, use it
-      entry.search.score = score;
+    if (score !== null && (!Number.isNaN(score))) {
+      // Clamp the range of the score from 0 to 1
+      entry.search.score = Math.min(1, Math.max(score, 0));
     }
     this.entry.push(entry);
     this.total++;

--- a/src/searchset.ts
+++ b/src/searchset.ts
@@ -59,22 +59,24 @@ export class SearchSet implements SearchSetBundle {
   addEntry(study: ResearchStudy, score?: number, mode?: SearchEntryMode): void;
   // This overload is sort of implied, but TypeScript needs us to give it outright
   addEntry(studyOrEntry: SearchBundleEntry | ResearchStudy): void;
-  addEntry(studyOrEntry: SearchBundleEntry | ResearchStudy, score = 1, mode: SearchEntryMode = 'match'): void {
+  addEntry(studyOrEntry: SearchBundleEntry | ResearchStudy, score: number | null = null, mode: SearchEntryMode = 'match'): void {
     const entry: SearchBundleEntry = isResearchStudy(studyOrEntry)
       ? { resource: studyOrEntry, search: { mode: mode } }
       : studyOrEntry;
     // Grab the score out of the entry if one was given
     if (entry.search.score) score = entry.search.score;
-    // This somewhat bizarre logic is to catch NaN
-    if (!(score >= 0 && score <= 1)) {
-      if (score < 0) {
-        score = 0;
-      } else {
-        score = 1;
+    if (score !== null) {
+      // This somewhat bizarre logic is to catch NaN
+      if (!(score >= 0 && score <= 1)) {
+        if (score < 0) {
+          score = 0;
+        } else {
+          score = 1;
+        }
       }
+      // Now that we've made score valid, use it
+      entry.search.score = score;
     }
-    // Now that we've made score valid, use it
-    entry.search.score = score;
     this.entry.push(entry);
     this.total++;
   }


### PR DESCRIPTION
Changes the API so that not setting a score when adding an entry does not set the score to anything. Also updates the CT.gov backup code to include the site address in generated locations if present.

**Submitter:**
- [x] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [x]	Does an update need to be made to the documentation with these changes? *Yes, to the API doc comments, which was made.*
- [x]	Make sure there is an update to service library reference in the service wrappers/template once this PR is merged. *This will apply to the BreastCancerTrials.org wrapper.*
- [x]	Does an update need to be made to the engine? **Yes**: Scores are still displaying even when they are not in the response.
- [x] Was the new feature tested by unit tests? **Yes**
- [x] Was the new feature tested by a manual, end-to-end test? **Yes** *(It was checked against the BreastCancerTrials.org wrapper.)*
