### PR TITLE
Add ability to specify a URL prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ service.listen().catch(err => {
 
 ## Configuring the service
 
-The `ClinicalTrialMatchingService` can optionally take a `Configuration` object that describes the server's configuration. At present, it has two fields, that are both handed off to the underlying `net.Server#listen` directly:
+The `ClinicalTrialMatchingService` can optionally take a `Configuration` object that describes the server's configuration.
 
  * `port` - the port to listen on, must be in the range 0-65535. If 0, a default open port is used.
  * `host` - the host address to bind to
+ * `urlPrefix` - if given, the prefix to use for all configured request paths (note that it's normalized: `"/prefix"` and `"prefix/"` both cause the application to generate paths that begin with `"/prefix/"`.)
 
-For more information about how these are used, read the [Node.js `net.Server#listen` documentation](https://nodejs.org/dist/latest-v12.x/docs/api/net.html#net_server_listen_port_host_backlog_callback).
+For more information about how `port` and `host` are used, read the [Node.js `net.Server#listen` documentation](https://nodejs.org/dist/latest-v12.x/docs/api/net.html#net_server_listen_port_host_backlog_callback).
+
+Note: If the `PASSENGER_BASE_URI` environment variable is set, this is used as the value for `urlPrefix`. This is to provide compatibility when running within Passenger with a base URI set via Passenger's configuration.
 
 The `configFromEnv()` helper function can be used to pull in all environment variables (or all environment variables starting with a given prefix) into a configuration object that can be passed to the `ClinicalTrialMatchingService` constructor. The function will remove the prefix (if one is given) and lowercase the key for all environment variables in the final configuration (meaning `PORT` and `port` both specify a value for `port`). The function has the following overloads:
 


### PR DESCRIPTION
This adds support for two key features:

1. Allows a URL prefix to be set via either the `urlPrefix` configuration option or via the `PASSENGER_BASE_URI` environment variable (which is automatically set via Passenger when loaded within a Passenger environment).
2. Allows the Express instance used to be passed in via an options collection, which allows it to be pre-configured with middleware designed to work within whatever environment the service is running. (It's unlikely this will be used too much, but it also turns out to be quite useful for the tests.)

**Submitter:**
- [x] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [x]	Does an update need to be made to the documentation with these changes? *Yes*
- [ ]	Make sure there is an update to service library reference in the service wrappers/template once this PR is merged.
- N/A	Does an update need to be made to the engine?
- [x] Was the new feature tested by unit tests? *Yes*
- [x] Was the new feature tested by a manual, end-to-end test? *Yes*
