### PR TITLE
Cache missing trials

### DIFF
--- a/scripts/loader.py
+++ b/scripts/loader.py
@@ -1,0 +1,42 @@
+#######
+#
+# usage: python3 loader.py [absolute_path_to_records]
+#
+#######
+
+import json, os, glob, requests, csv, sys
+
+# List the directory of the records and retrieve only the .json files from that directory
+recordDirectory = sys.argv[1]
+os.chdir(recordDirectory)
+records = glob.glob('*.json')
+resultsDirectory = "results"
+
+# Create the FHIR Parameters resource
+zipCode = "02021"
+travelRadius = "100"
+parameter = {"resource": 
+{"resourceType": "Parameters",
+ "id": "0",
+ "parameter": [{"name": "zipCode", "valueString":zipCode}]}}
+
+# Loop through each record
+for record in records:
+	print(record)
+	with open(record) as f:
+		data = json.load(f)
+
+		# Add the parameter resource to the record
+		data["entry"].append(parameter)
+		data["type"] = "collection"
+
+		# Send the patient bundle to the wrapper
+		response = requests.post('http://localhost:3000/getClinicalTrial', data=json.dumps(data), headers={"Content-Type":"application/json"})
+		researchStudies = response.json()
+
+		# Create a .csv file in the resultsDirectory and write the NCTID of each match to that file 
+		if (researchStudies["total"] > 0):
+			with open(resultsDirectory + "/" + record[:-5] + ".csv", mode='w') as result_file:
+				writer = csv.writer(result_file)
+				for entry in researchStudies["entry"]:
+					writer.writerow([entry["resource"]["id"]])

--- a/scripts/loader.py
+++ b/scripts/loader.py
@@ -22,21 +22,21 @@ parameter = {"resource":
 
 # Loop through each record
 for record in records:
-	print(record)
-	with open(record) as f:
-		data = json.load(f)
+  print(record)
+  with open(record) as f:
+    data = json.load(f)
 
-		# Add the parameter resource to the record
-		data["entry"].append(parameter)
-		data["type"] = "collection"
+    # Add the parameter resource to the record
+    data["entry"].append(parameter)
+    data["type"] = "collection"
 
-		# Send the patient bundle to the wrapper
-		response = requests.post('http://localhost:3000/getClinicalTrial', data=json.dumps(data), headers={"Content-Type":"application/json"})
-		researchStudies = response.json()
+    # Send the patient bundle to the wrapper
+    response = requests.post('http://localhost:3000/getClinicalTrial', data=json.dumps(data), headers={"Content-Type":"application/json"})
+    researchStudies = response.json()
 
-		# Create a .csv file in the resultsDirectory and write the NCTID of each match to that file 
-		if (researchStudies["total"] > 0):
-			with open(resultsDirectory + "/" + record[:-5] + ".csv", mode='w') as result_file:
-				writer = csv.writer(result_file)
-				for entry in researchStudies["entry"]:
-					writer.writerow([entry["resource"]["id"]])
+    # Create a .csv file in the resultsDirectory and write the NCTID of each match to that file 
+    if (researchStudies["total"] > 0):
+      with open(resultsDirectory + "/" + record[:-5] + ".csv", mode='w') as result_file:
+        writer = csv.writer(result_file)
+        for entry in researchStudies["entry"]:
+          writer.writerow([entry["resource"]["id"]])

--- a/spec/clinicaltrialsgov.spec.ts
+++ b/spec/clinicaltrialsgov.spec.ts
@@ -137,6 +137,7 @@ describe('parseClinicalTrialXML', () => {
 describe('CacheEntry', () => {
   // Constant start time
   const startTime = new Date(2021, 0, 21, 12, 0, 0, 0);
+  // Use the same log that the service would use for invoking stubs
   const log = debuglog('ctgovservice');
   describe('createdAt', () => {
     beforeAll(() => {

--- a/src/clinicaltrialsgov.ts
+++ b/src/clinicaltrialsgov.ts
@@ -251,7 +251,7 @@ export class CacheEntry {
 
   /**
    * Loads the underlying file. If the entry is still pending, then the file is read once the entry is ready. This may
-   * resolve to null if the clinical study does not exist (in which case an empty file will be cached).
+   * resolve to null if the clinical study does not exist in the results.
    */
   load(log: Logger): Promise<ClinicalStudy | null> {
     // Move last access to now
@@ -280,7 +280,9 @@ export class CacheEntry {
           // Again bump last access to now since the access has completed
           this._lastAccess = new Date();
           if (data.length === 0) {
-            // If empty, we cached a "missing" response
+            // Sometimes files end up empty - this appears to be a bug?
+            // It's unclear what causes this to happen
+            log('Warning: %s is empty on read', this.filename);
             resolve(null);
           } else {
             // Resolving with a Promise essentially "chains" that Promise

--- a/src/clinicaltrialsgov.ts
+++ b/src/clinicaltrialsgov.ts
@@ -884,6 +884,7 @@ export class ClinicalTrialsGovService {
       // (This also potentially allows us to do additional cleanup on close if an error happened.)
       let success = true;
       dataStream.pipe(fs.createWriteStream(filename)).on('error', (err) => {
+        this.log(`Unable to create file [%s]: %o`, filename, err);
         // If the cache entry exists in pending mode, delete it - we failed to create this entry
         // TODO: Does this failure destroy the existing cache entry?
         const entry = this.cache.get(nctNumber);

--- a/src/server.ts
+++ b/src/server.ts
@@ -171,37 +171,32 @@ export class ClinicalTrialMatchingService {
 
   getClinicalTrial(request: express.Request, response: express.Response): void {
     const postBody = request.body as Record<string, unknown>;
-    if ('patientData' in postBody) {
-      const patientBundle = (typeof postBody.patientData === 'string'
-        ? JSON.parse(postBody.patientData)
-        : postBody.patientData) as Record<string, unknown>;
-      if (isBundle(patientBundle)) {
-        // Error handler for exceptions raised (as it should be handled on the
-        // resulting Promise and if invoking the matcher itself fails)
-        const handleError = (error: unknown): void => {
-          if (isHttpError(error)) {
-            response.status(restrictToHttpErrors(error.httpStatus)).send({ error: error.message });
-          } else {
-            console.error('An unexpected internal server error occurred:');
-            console.error(error);
-            response.status(500).send({ error: 'Internal server error', exception: Object.prototype.toString.call(error) as string });
-          }
-        };
-        try {
-          this.matcher(patientBundle)
-            .then((result) => {
-              response.status(200).send(JSON.stringify(result));
-            })
-            .catch(handleError);
-        } catch (ex) {
-          handleError(ex);
+    const patientBundle = (typeof postBody === 'string'
+      ? JSON.parse(postBody)
+      : postBody) as Record<string, unknown>;
+    if (isBundle(patientBundle)) {
+      // Error handler for exceptions raised (as it should be handled on the
+      // resulting Promise and if invoking the matcher itself fails)
+      const handleError = (error: unknown): void => {
+        if (isHttpError(error)) {
+          response.status(restrictToHttpErrors(error.httpStatus)).send({ error: error.message });
+        } else {
+          console.error('An unexpected internal server error occurred:');
+          console.error(error);
+          response.status(500).send({ error: 'Internal server error', exception: Object.prototype.toString.call(error) as string });
         }
-      } else {
-        response.status(400).send({ error: 'Invalid patientBundle' });
+      };
+      try {
+        this.matcher(patientBundle)
+          .then((result) => {
+            response.status(200).send(JSON.stringify(result));
+          })
+          .catch(handleError);
+      } catch (ex) {
+        handleError(ex);
       }
     } else {
-      // request missing json fields
-      response.status(400).send({ error: 'Request missing required fields' });
+      response.status(400).send({ error: 'Invalid patientBundle' });
     }
   }
 


### PR DESCRIPTION
This PR improves unzipping files for cache backup, adds a script that can be used to run a batch of patient records, and updates how to receive the bundle by removing the outer JSON object.

Pull requests into the clinical-trial-matching-service require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Make sure there is an update to service library reference in the service wrappers/template once this PR is merged.
- [ ]	Does an update need to be made to the engine?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
