### PR TITLE
Fix ZIP extraction

### DIFF
--- a/src/clinicaltrialsgov.ts
+++ b/src/clinicaltrialsgov.ts
@@ -832,6 +832,7 @@ export class ClinicalTrialsGovService {
         } else if (zipFile) {
           // Now that we have the file, it's time to add some events to it
           zipFile.once('error', (err) => {
+            this.log('Error reading ZIP file: %o', err);
             reject(err);
           });
           zipFile.on('entry', (entry: yauzl.Entry) => {
@@ -850,6 +851,7 @@ export class ClinicalTrialsGovService {
                     zipFile.openReadStream(entry, (err, entryStream) => {
                       if (err) {
                         this.log('Error reading entry %s: skipping!', entry.fileName);
+                        zipFile.readEntry();
                       } else if (entryStream) {
                         this.addCacheEntry(nctNumber, entryStream).then(() => {
                           zipFile.readEntry();
@@ -857,9 +859,9 @@ export class ClinicalTrialsGovService {
                           this.log('Error extracting %s: %o', entry.fileName, err);
                           zipFile.readEntry();
                         });
-                        return;
                       }
                     });
+                    return;
                   }
                 } else {
                   this.log('Skipping invalid entry [%s]: not a valid NCT number/file name', entry.fileName);


### PR DESCRIPTION
This fixes a slight async logic bug that caused readEntry() to possibly be called multiple times for a single entry, potentially putting YAUZL into a weird state where it would try and read the wrong parts of the ZIP file as a ZIP entry, causing the entire unzip process to fail.

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Make sure there is an update to service library reference in the service wrappers/template once this PR is merged.
- [ ]	Does an update need to be made to the engine?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
