### PR TITLE
Retrieve contacts, arms, interventions, and study design

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clinical-trial-matching-service",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Provides a core library for interacting with the clinical-trial-matching-engine",
   "homepage": "https://github.com/mcode/clinical-trial-matching-service",
   "bugs": "https://github.com/mcode/clinical-trial-matching-service/issues",
@@ -10,7 +10,9 @@
     "Daniel Potter",
     "Nikhil Gaddam",
     "Zach Lister",
-    "Lauren Levine"
+    "Lauren Levine",
+    "Robi Scalfani",
+    "Christine Duong"
   ],
   "main": "dist/index.js",
   "repository": {

--- a/spec/clinicaltrialsgov.spec.ts
+++ b/spec/clinicaltrialsgov.spec.ts
@@ -1513,7 +1513,7 @@ describe('ClinicalTrialsGovService', () => {
               title: 'Name',
               subtitle: 'Other name',
               type: { text: 'Behavioral' },
-              subjectCodeableConcept: { text: 'Arm'}
+              subjectCodeableConcept: { text: 'Arm' }
             })
           );
         }
@@ -1610,7 +1610,6 @@ describe('ClinicalTrialsGovService', () => {
       }
     });
 
-
     it('fills in contacts even with missing information', () => {
       const researchStudy = new ResearchStudyObj('id');
       const result = ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
@@ -1637,15 +1636,11 @@ describe('ClinicalTrialsGovService', () => {
           jasmine.arrayContaining([
             jasmine.objectContaining({
               name: 'First Last',
-              telecom: [
-                { system: 'email', value: 'email@example.com', use: 'work' },
-              ]
+              telecom: [{ system: 'email', value: 'email@example.com', use: 'work' }]
             }),
             jasmine.objectContaining({
               name: ' Middle2, DO',
-              telecom: [
-                { system: 'phone', value: '1234567890', use: 'work' }
-              ]
+              telecom: [{ system: 'phone', value: '1234567890', use: 'work' }]
             })
           ])
         );

--- a/spec/clinicaltrialsgov.spec.ts
+++ b/spec/clinicaltrialsgov.spec.ts
@@ -15,9 +15,6 @@ import trialFilled from './data/complete_study.json';
 import { ClinicalStudy, StatusEnum } from '../src/clinicalstudy';
 import { createClinicalStudy } from './support/clinicalstudy-factory';
 import { createResearchStudy } from './support/researchstudy-factory';
-import Item from 'mock-fs/lib/item';
-import { fail } from 'assert';
-import { exception } from 'console';
 import { PlanDefinition } from '../dist/fhir-types';
 
 function specFilePath(specFilePath: string): string {
@@ -1337,7 +1334,7 @@ describe('ClinicalTrialsGovService', () => {
       const researchStudy = new ResearchStudyObj('id');
       researchStudy.category = [{ text: 'Study Type: Example' }];
 
-      const result = ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
+      ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
         study_type: ['Interventional'],
         study_design_info: [
           {
@@ -1375,7 +1372,7 @@ describe('ClinicalTrialsGovService', () => {
       // Empty category but there is an object there for the sake of this test.
       researchStudy.category = [{}];
 
-      const result = ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
+      ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
         study_type: ['Interventional']
       });
 

--- a/spec/data/complete_study.json
+++ b/spec/data/complete_study.json
@@ -10,6 +10,20 @@
   ],
   "title": "PALbociclib CoLlaborative Adjuvant Study: A Randomized Phase III Trial of Palbociclib With Standard Adjuvant Endocrine Therapy Versus Standard Adjuvant Endocrine Therapy Alone for Hormone Receptor Positive (HR+) / Human Epidermal Growth Factor Receptor 2 (HER2)-Negative Early Breast Cancer",
   "status": "active",
+  "protocol":[
+      {
+         "reference":"#plan-0",
+         "type":"PlanDefinition"
+      },
+      {
+         "reference":"#plan-1",
+         "type":"PlanDefinition"
+      },
+      {
+         "reference":"#plan-2",
+         "type":"PlanDefinition"
+      }
+   ],
   "condition": [{ "text": "Breast Cancer" }],
   "contact": [{ "name": "Edward Habermehl" }],
   "keyword": [{ "text": "HR+/HER2- breast cancer" }, { "text": "Palbociclib" }],
@@ -47,18 +61,77 @@
     ],
     "text": "Phase 3"
   },
-  "category": [{ "text": "Interventional" }],
+  "category": [
+    {
+      "text": "Study Type: Interventional"
+    },
+    {
+      "text": "Intervention Model: Parallel Assignment"
+    },
+    {
+      "text": "Primary Purpose: Treatment"
+    },
+    {
+      "text": "Masking: None (Open Label)"
+    },
+    {
+      "text": "Allocation: Randomized"
+    }
+  ],
   "site": [
     {
       "reference": "#site",
       "type": "Location"
     }
   ],
+   "arm":[
+      {
+         "name":"Arm A",
+         "type":{
+            "coding":[
+               {
+                  "code":"Experimental",
+                  "display":"Experimental"
+               }
+            ],
+            "text":"Experimental"
+         },
+         "description":"Palbociclib at a dose of 125 mg orally once daily, Day 1 to Day 21 followed by 7 days off treatment in a 28-day cycle for a total duration of 2 years, in addition to standard adjuvant endocrine therapy for a duration of at least 5 years."
+      },
+      {
+         "name":"Arm B",
+         "type":{
+            "coding":[
+               {
+                  "code":"Other",
+                  "display":"Other"
+               }
+            ],
+            "text":"Other"
+         },
+         "description":"Standard adjuvant endocrine therapy for a duration of at least 5 years."
+      }
+   ],
   "contained": [
     {
       "resourceType": "Location",
       "id": "site",
       "name": "Site"
+    },
+    {
+      "resourceType": "PlanDefinition",
+      "id": "plan-0",
+      "name": "Plan 0"
+    },
+    {
+      "resourceType": "PlanDefinition",
+      "id": "plan-1",
+      "name": "Plan 1"
+    },
+    {
+      "resourceType": "PlanDefinition",
+      "id": "plan-2",
+      "name": "Plan 2"
     }
   ]
 }

--- a/spec/data/resource.json
+++ b/spec/data/resource.json
@@ -449,7 +449,7 @@
           },
           "category": [
             {
-              "text": "Interventional"
+              "text": "Study Type: Interventional"
             }
           ],
           "condition": [

--- a/spec/data/resource.json
+++ b/spec/data/resource.json
@@ -98,7 +98,19 @@
           },
           "category": [
             {
-              "text": "Interventional"
+              "text": "Study Type: Interventional"
+            },
+            {
+              "text": "Intervention Model: Parallel Assignment"
+            },
+            {
+              "text": "Primary Purpose: Treatment"
+            },
+            {
+              "text": "Masking: None (Open Label)"
+            },
+            {
+              "text": "Allocation: Randomized"
             }
           ],
           "condition": [
@@ -200,7 +212,7 @@
           },
           "category": [
             {
-              "text": "Interventional"
+              "text": "Study Type: Interventional"
             }
           ],
           "condition": [

--- a/src/clinicalstudy.ts
+++ b/src/clinicalstudy.ts
@@ -141,7 +141,7 @@ export type EnrollmentStruct =
 // Arm Group
 
 export interface ArmGroupStruct {
-  arm_group_label?: One<string>;
+  arm_group_label: One<string>;
   arm_group_type?: One<string>;
   description?: One<string>;
 }

--- a/src/clinicalstudy.ts
+++ b/src/clinicalstudy.ts
@@ -141,7 +141,7 @@ export type EnrollmentStruct =
 // Arm Group
 
 export interface ArmGroupStruct {
-  arm_group_label: One<string>;
+  arm_group_label?: One<string>;
   arm_group_type?: One<string>;
   description?: One<string>;
 }

--- a/src/clinicalstudy.ts
+++ b/src/clinicalstudy.ts
@@ -465,14 +465,14 @@ export interface ClinicalStudy {
   number_of_groups?: One<XSInteger>;
   enrollment?: One<EnrollmentStruct>;
   condition?: Unbounded<string>;
-  // arm_group: arm_group_struct; //  minOccurs="0" maxOccurs="unbounded"
-  // intervention: intervention_struct; //  minOccurs="0" maxOccurs="unbounded"
+  arm_group?: Unbounded<ArmGroupStruct>; //  minOccurs="0" maxOccurs="unbounded"
+  intervention?: Unbounded<InterventionStruct>; //  minOccurs="0" maxOccurs="unbounded"
   // biospec_retention: biospec_retention_enum; //  minOccurs="0"
   // biospec_descr: textblock_struct; //  minOccurs="0"
   eligibility?: One<EligibilityStruct>; //  minOccurs="0"
   // overall_official: investigator_struct; //  minOccurs="0" maxOccurs="unbounded"
-  // overall_contact: contact_struct; //  minOccurs="0"
-  // overall_contact_backup: contact_struct; //  minOccurs="0"
+  overall_contact?: One<ContactStruct>; //  minOccurs="0"
+  overall_contact_backup?: One<ContactStruct>; //  minOccurs="0"
   location?: Unbounded<LocationStruct>;
   // location_countries: countries_struct; //  minOccurs="0"
   // removed_countries: countries_struct; //  minOccurs="0"

--- a/src/clinicaltrialsgov.ts
+++ b/src/clinicaltrialsgov.ts
@@ -234,7 +234,11 @@ export class CacheEntry {
    * @param filename the file name of the entry
    * @param options the file stats (if the file exists) or a flag indicating it's pending (being downloaded still)
    */
-  constructor(cache: ClinicalTrialsGovService, public filename: string, options: { stats?: fs.Stats; pending?: boolean }) {
+  constructor(
+    cache: ClinicalTrialsGovService,
+    public filename: string,
+    options: { stats?: fs.Stats; pending?: boolean }
+  ) {
     this._cache = cache;
     if (options.stats) {
       // Default to using the metadata from the fs.Stats object
@@ -1038,7 +1042,7 @@ export function createClinicalTrialsGovService(
 /**
  * Updates a research study with data from a clinical study off the ClinicalTrials.gov website. This will only update
  * fields that do not have data, it will not overwrite any existing data.
- * 
+ *
  * Mapping as defined by https://www.hl7.org/fhir/researchstudy-mappings.html#clinicaltrials-gov
  *
  * @param result the research study to update
@@ -1085,52 +1089,54 @@ export function updateResearchStudyWithClinicalStudy(
       };
     }
   }
- 
-  // ------- Category 
+
+  // ------- Category
   // Since we may not have all of the Study design in the result, we need to do a merge of data
   const studyType = study.study_type;
-  const categories:CodeableConcept[] = result.category ? result.category : [];
+  const categories: CodeableConcept[] = result.category ? result.category : [];
 
   // We need to determine what categories have already been declared.
-  const types = categories.map(item => { const sep = item.text?.split(":"); return sep ? sep[0] : '' ;});
-  
-  if (studyType && !types.includes("Study Type")) {
-    categories.push({ text: "Study Type: " + studyType[0] });
+  const types = categories.map((item) => {
+    const sep = item.text?.split(':');
+    return sep ? sep[0] : '';
+  });
+
+  if (studyType && !types.includes('Study Type')) {
+    categories.push({ text: 'Study Type: ' + studyType[0] });
   }
 
   const study_design = study.study_design_info;
   if (study_design) {
     const info = study_design[0];
 
-    if (info.intervention_model && !types.includes("Intervention Model")) {
-            categories.push({ text: "Intervention Model: " + info.intervention_model[0] });
+    if (info.intervention_model && !types.includes('Intervention Model')) {
+      categories.push({ text: 'Intervention Model: ' + info.intervention_model[0] });
     }
 
-    if (info.primary_purpose && !types.includes("Primary Purpose")) {
-            categories.push({ text: "Primary Purpose: " + info.primary_purpose[0] });
+    if (info.primary_purpose && !types.includes('Primary Purpose')) {
+      categories.push({ text: 'Primary Purpose: ' + info.primary_purpose[0] });
     }
 
-    if (info.masking && !types.includes("Masking")) {
-            categories.push({ text: "Masking: " + info.masking[0] });
+    if (info.masking && !types.includes('Masking')) {
+      categories.push({ text: 'Masking: ' + info.masking[0] });
     }
 
-    if (info.allocation && !types.includes("Allocation")) {
-            categories.push({ text: "Allocation: " + info.allocation[0] });
+    if (info.allocation && !types.includes('Allocation')) {
+      categories.push({ text: 'Allocation: ' + info.allocation[0] });
     }
 
-    if (info.time_perspective && !types.includes("Time Perspective")) {
-            categories.push({ text: "Time Perspective: " + info.time_perspective[0] });
+    if (info.time_perspective && !types.includes('Time Perspective')) {
+      categories.push({ text: 'Time Perspective: ' + info.time_perspective[0] });
     }
 
-    if (info.observational_model&& !types.includes("Observation Model")) {
-            categories.push({ text: "Observation Model: " + info.observational_model[0] });
+    if (info.observational_model && !types.includes('Observation Model')) {
+      categories.push({ text: 'Observation Model: ' + info.observational_model[0] });
     }
-
   }
-  
+
   if (categories.length > 1) result.category = categories;
-  // ------- Category 
-  
+  // ------- Category
+
   if (!result.status) {
     const overallStatus = study.overall_status;
     if (overallStatus) {
@@ -1184,68 +1190,70 @@ export function updateResearchStudyWithClinicalStudy(
         addToContainer<ResearchStudy, Reference, 'site'>(result, 'site', addContainedResource(result, fhirLocation));
       }
     }
-
   }
 
   if (!result.arm) {
     if (study.arm_group) {
-      for(const study_arm of study.arm_group) {
-        const arm:Arm = {
-          ...(study_arm.arm_group_label && {name: study_arm.arm_group_label[0]}),
-          ...(study_arm.arm_group_type && {type: {
-            coding: [
+      for (const study_arm of study.arm_group) {
+        const arm: Arm = {
+          ...(study_arm.arm_group_label && { name: study_arm.arm_group_label[0] }),
+          ...(study_arm.arm_group_type && {
+            type: {
+              coding: [
                 {
                   code: study_arm.arm_group_type[0],
                   display: study_arm.arm_group_type[0]
                 }
-            ],
-            text: study_arm.arm_group_type[0]
-          }}),
-          ...(study_arm.description && {description: study_arm.description[0]})
+              ],
+              text: study_arm.arm_group_type[0]
+            }
+          }),
+          ...(study_arm.description && { description: study_arm.description[0] })
         };
 
         addToContainer<ResearchStudy, Arm, 'arm'>(result, 'arm', arm);
       }
     }
-
   }
 
   if (!result.protocol) {
     if (study.intervention) {
-      let index = 0; 
+      let index = 0;
       for (const intervention of study.intervention) {
-        if(intervention.arm_group_label) {
+        if (intervention.arm_group_label) {
           for (const arm_group of intervention.arm_group_label) {
-            let plan: PlanDefinition = { resourceType: 'PlanDefinition', status: 'unknown', id: 'plan-' + index++};
+            let plan: PlanDefinition = { resourceType: 'PlanDefinition', status: 'unknown', id: 'plan-' + index++ };
 
             plan = {
               ...plan,
               ...(intervention.description && { description: intervention.description[0] }),
-              ...(intervention.intervention_name && { title: intervention.intervention_name[0] } ),
+              ...(intervention.intervention_name && { title: intervention.intervention_name[0] }),
               ...(intervention.other_name && { subtitle: intervention.other_name[0] }),
-              ...(intervention.intervention_type && {type: { text: intervention.intervention_type[0] } } ),
-              ...({ subjectCodeableConcept: { text: arm_group } } )
+              ...(intervention.intervention_type && { type: { text: intervention.intervention_type[0] } }),
+              ...{ subjectCodeableConcept: { text: arm_group } }
             };
 
-            addToContainer<ResearchStudy, Reference, 'protocol'>(result, 'protocol', addContainedResource(result, plan));
+            addToContainer<ResearchStudy, Reference, 'protocol'>(
+              result,
+              'protocol',
+              addContainedResource(result, plan)
+            );
           }
-
         } else {
-          let plan: PlanDefinition = { resourceType: 'PlanDefinition', status: 'unknown', id: 'plan-' + index++};
+          let plan: PlanDefinition = { resourceType: 'PlanDefinition', status: 'unknown', id: 'plan-' + index++ };
 
           plan = {
             ...plan,
             ...(intervention.description && { description: intervention.description[0] }),
-            ...(intervention.intervention_name && { title: intervention.intervention_name[0] } ),
+            ...(intervention.intervention_name && { title: intervention.intervention_name[0] }),
             ...(intervention.other_name && { subtitle: intervention.other_name[0] }),
-            ...(intervention.intervention_type && {type: { text: intervention.intervention_type[0] } } )
+            ...(intervention.intervention_type && { type: { text: intervention.intervention_type[0] } })
           };
 
           addToContainer<ResearchStudy, Reference, 'protocol'>(result, 'protocol', addContainedResource(result, plan));
         }
       }
     }
-
   }
 
   if (!result.contact) {
@@ -1254,30 +1262,31 @@ export function updateResearchStudyWithClinicalStudy(
     for (const contact of contacts) {
       if (contact != undefined) {
         const contact_info = contact[0];
-        const contact_name:string = (contact_info.first_name ? contact_info.first_name[0] : '' ) 
-                                  + (contact_info.middle_name ? ' ' + contact_info.middle_name[0] : '' )
-                                  + (contact_info.last_name ? ' ' + contact_info.last_name[0] : '' )
-                                  + (contact_info.degrees ? ", " + contact_info.degrees[0] : '' )
+        const contact_name: string =
+          (contact_info.first_name ? contact_info.first_name[0] : '') +
+          (contact_info.middle_name ? ' ' + contact_info.middle_name[0] : '') +
+          (contact_info.last_name ? ' ' + contact_info.last_name[0] : '') +
+          (contact_info.degrees ? ', ' + contact_info.degrees[0] : '');
 
-        const fhir_contact:ContactDetail = { name: contact_name}
+        const fhir_contact: ContactDetail = { name: contact_name };
         if (contact_info.email) {
-            addToContainer<ContactDetail, ContactPoint, 'telecom'>(fhir_contact, 'telecom', {
-              system: 'email',
-              value: contact_info.email[0],
-              use: 'work'
-            });
+          addToContainer<ContactDetail, ContactPoint, 'telecom'>(fhir_contact, 'telecom', {
+            system: 'email',
+            value: contact_info.email[0],
+            use: 'work'
+          });
         }
         if (contact_info.phone) {
-            addToContainer<ContactDetail, ContactPoint, 'telecom'>(fhir_contact, 'telecom', {
-              system: 'phone',
-              value: contact_info.phone[0],
-              use: 'work'
-            });
+          addToContainer<ContactDetail, ContactPoint, 'telecom'>(fhir_contact, 'telecom', {
+            system: 'phone',
+            value: contact_info.phone[0],
+            use: 'work'
+          });
         }
         addToContainer<ResearchStudy, ContactDetail, 'contact'>(result, 'contact', fhir_contact);
       }
     }
   }
-  
+
   return result;
 }

--- a/src/clinicaltrialsgov.ts
+++ b/src/clinicaltrialsgov.ts
@@ -1204,7 +1204,7 @@ export function updateResearchStudyWithClinicalStudy(
           ...(study_arm.description && {description: study_arm.description[0]})
         };
 
-        if (arm.name) addToContainer<ResearchStudy, Arm, 'arm'>(result, 'arm', arm);
+        addToContainer<ResearchStudy, Arm, 'arm'>(result, 'arm', arm);
       }
     }
 
@@ -1227,7 +1227,7 @@ export function updateResearchStudyWithClinicalStudy(
               ...({ subjectCodeableConcept: { text: arm_group } } )
             };
 
-            if (plan.title) addToContainer<ResearchStudy, Reference, 'protocol'>(result, 'protocol', addContainedResource(result, plan));
+            addToContainer<ResearchStudy, Reference, 'protocol'>(result, 'protocol', addContainedResource(result, plan));
           }
 
         } else {
@@ -1241,7 +1241,7 @@ export function updateResearchStudyWithClinicalStudy(
             ...(intervention.intervention_type && {type: { text: intervention.intervention_type[0] } } )
           };
 
-          if (plan.title) addToContainer<ResearchStudy, Reference, 'protocol'>(result, 'protocol', addContainedResource(result, plan));
+          addToContainer<ResearchStudy, Reference, 'protocol'>(result, 'protocol', addContainedResource(result, plan));
         }
       }
     }
@@ -1266,6 +1266,7 @@ export function updateResearchStudyWithClinicalStudy(
               value: contact_info.email[0],
               use: 'work'
             });
+        }
         if (contact_info.phone) {
             addToContainer<ContactDetail, ContactPoint, 'telecom'>(fhir_contact, 'telecom', {
               system: 'phone',
@@ -1277,6 +1278,6 @@ export function updateResearchStudyWithClinicalStudy(
       }
     }
   }
-}
+  
   return result;
 }

--- a/src/clinicaltrialsgov.ts
+++ b/src/clinicaltrialsgov.ts
@@ -1089,10 +1089,10 @@ export function updateResearchStudyWithClinicalStudy(
   // ------- Category 
   // Since we may not have all of the Study design in the result, we need to do a merge of data
   const studyType = study.study_type;
-  let categories:CodeableConcept[] = result.category ? result.category : [];
+  const categories:CodeableConcept[] = result.category ? result.category : [];
 
   // We need to determine what categories have already been declared.
-  let types = categories.map(item => { const sep = item.text?.split(":"); return sep ? sep[0] : '' ;});
+  const types = categories.map(item => { const sep = item.text?.split(":"); return sep ? sep[0] : '' ;});
   
   if (studyType && !types.includes("Study Type")) {
     categories.push({ text: "Study Type: " + studyType[0] });
@@ -1249,7 +1249,7 @@ export function updateResearchStudyWithClinicalStudy(
   }
 
   if (!result.contact) {
-    let contacts = [study.overall_contact, study.overall_contact_backup];
+    const contacts = [study.overall_contact, study.overall_contact_backup];
 
     for (const contact of contacts) {
       if (contact != undefined) {

--- a/src/fhir-types.ts
+++ b/src/fhir-types.ts
@@ -160,7 +160,7 @@ export interface Reference {
   display?: string;
 }
 
-export type PublicationStatus = '	draft' | 'active' | 'retired' | 'unknown';
+export type PublicationStatus = 'draft' | 'active' | 'retired' | 'unknown';
 
 export interface PlanDefinition extends BaseResource {
   resourceType: 'PlanDefinition',

--- a/src/fhir-types.ts
+++ b/src/fhir-types.ts
@@ -160,6 +160,18 @@ export interface Reference {
   display?: string;
 }
 
+export type PublicationStatus = '	draft' | 'active' | 'retired' | 'unknown';
+
+export interface PlanDefinition extends BaseResource {
+  resourceType: 'PlanDefinition',
+  status: PublicationStatus,
+  type?: CodeableConcept,
+  title?: string,
+  subtitle?: string,
+  description?: string,
+  subjectCodeableConcept?: CodeableConcept 
+}
+
 // FHIR resources contained within ResearchStudy
 export interface Group extends BaseResource {
   resourceType: 'Group';
@@ -207,7 +219,7 @@ export interface HumanName {
   text: string;
 }
 
-export type ContainedResource = Group | Location | Organization | Practitioner;
+export type ContainedResource = Group | Location | Organization | Practitioner | PlanDefinition;
 
 /**
  * Codes from https://www.hl7.org/fhir/codesystem-research-study-status.html
@@ -229,6 +241,7 @@ export interface ResearchStudy extends BaseResource {
   resourceType: 'ResearchStudy';
   identifier?: Identifier[];
   title?: string;
+  protocol?: Reference[];
   status?: ResearchStudyStatus;
   phase?: CodeableConcept;
   category?: CodeableConcept[];

--- a/src/research-study.ts
+++ b/src/research-study.ts
@@ -113,6 +113,7 @@ export class ResearchStudy implements IResearchStudy {
   id?: string;
   identifier?: Identifier[];
   title?: string;
+  protocol?: Reference[];
   status?: ResearchStudyStatus;
   phase?: CodeableConcept;
   category?: CodeableConcept[];


### PR DESCRIPTION
Adds in the backup service (from CT.gov):
* Add overall contact (`overall_contact`) and overall backup contact (`overall_backup_contact`) to `ResearchStudy.contacts`
* Add arm groups to `ResearchStudy.arm`
* Add interventions and arm/interventions cross reference in `ResearchStudy.protocol`
* Adds in study design to `ResearchStudy.category`

**Submitter:**
- [X] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [X] Does an update need to be made to the documentation with these changes? **N/A**
- [X] Make sure there is an update to service library reference in the service wrappers/template once this PR is merged.
- [X] Does an update need to be made to the engine? **Yes, there is a following PR**
- [X] Was the new feature tested by unit tests?
- [X] Was the new feature tested by a manual, end-to-end test?
