### PR TITLE
Obtain the Period in the Backupservice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "clinical-trial-matching-service",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/spec/clinicaltrialsgov.spec.ts
+++ b/spec/clinicaltrialsgov.spec.ts
@@ -1571,6 +1571,93 @@ describe('ClinicalTrialsGovService', () => {
       }
     });
 
+    it('fills in period as VariableDate', () => {
+      const researchStudy = new ResearchStudyObj('id');
+      const result = ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
+        start_date: ["January 2022"],
+        completion_date: ["February 2023"]
+      });
+
+      expect(result.period).toBeDefined();
+      if (result.period) {
+        expect(result.period.start).toBeDefined();
+        expect(result.period.end).toBeDefined();
+
+        expect(result.period.start).toEqual(new Date("January 2022").toISOString());
+        expect(result.period.end).toEqual(new Date("February 2023").toISOString());
+      }
+
+    })
+
+    it('fills in period as VariableDateStruct', () => {
+      const researchStudy = new ResearchStudyObj('id');
+      const result = ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
+        start_date: [{ $: { type: "Actual"}, _: "January 2022" }],
+        completion_date:  [{ $: { type: "Actual"}, _: "February 2023" }],
+      });
+
+      expect(result.period).toBeDefined();
+      if (result.period) {
+        expect(result.period.start).toBeDefined();
+        expect(result.period.end).toBeDefined();
+
+        expect(result.period.start).toEqual(new Date("January 2022").toISOString());
+        expect(result.period.end).toEqual(new Date("February 2023").toISOString());
+      }
+    })
+
+    it('fills in start of period even without end', () => {
+      const researchStudy = new ResearchStudyObj('id');
+      const result = ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
+        start_date: ["January 2022"],
+      });
+
+      expect(result.period).toBeDefined();
+      if (result.period) {
+        expect(result.period.start).toBeDefined();
+        expect(result.period.end).not.toBeDefined();
+
+        expect(result.period.start).toEqual(new Date("January 2022").toISOString());
+      }
+
+    })
+
+    it('fills in end of period even without start', () => {
+      const researchStudy = new ResearchStudyObj('id');
+      const result = ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
+        completion_date: ["February 2023"]
+      });
+
+      expect(result.period).toBeDefined();
+      if (result.period) {
+        expect(result.period.start).not.toBeDefined();
+        expect(result.period.end).toBeDefined();
+
+        expect(result.period.end).toEqual(new Date("February 2023").toISOString());
+      }
+
+    })
+
+    it('does not fill in period if unknown', () => {
+      const researchStudy = new ResearchStudyObj('id');
+      const result = ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
+        start_date: ["Unknown"],
+        completion_date: ["Unknown"]
+      });
+
+      expect(result.period).not.toBeDefined();
+    })
+
+    it('does not fill in period if not a real date', () => {
+      const researchStudy = new ResearchStudyObj('id');
+      const result = ctg.updateResearchStudyWithClinicalStudy(researchStudy, {
+        start_date: ["Text that is not a date"],
+        completion_date: ["Text that is not a date"]
+      });
+
+      expect(result.period).not.toBeDefined();
+    })
+
     it('fills in description', () => {
       expect(updatedTrial.description).toBeDefined();
     });

--- a/spec/data/complete_study.json
+++ b/spec/data/complete_study.json
@@ -10,20 +10,20 @@
   ],
   "title": "PALbociclib CoLlaborative Adjuvant Study: A Randomized Phase III Trial of Palbociclib With Standard Adjuvant Endocrine Therapy Versus Standard Adjuvant Endocrine Therapy Alone for Hormone Receptor Positive (HR+) / Human Epidermal Growth Factor Receptor 2 (HER2)-Negative Early Breast Cancer",
   "status": "active",
-  "protocol":[
-      {
-         "reference":"#plan-0",
-         "type":"PlanDefinition"
-      },
-      {
-         "reference":"#plan-1",
-         "type":"PlanDefinition"
-      },
-      {
-         "reference":"#plan-2",
-         "type":"PlanDefinition"
-      }
-   ],
+  "protocol": [
+    {
+      "reference": "#plan-0",
+      "type": "PlanDefinition"
+    },
+    {
+      "reference": "#plan-1",
+      "type": "PlanDefinition"
+    },
+    {
+      "reference": "#plan-2",
+      "type": "PlanDefinition"
+    }
+  ],
   "condition": [{ "text": "Breast Cancer" }],
   "contact": [{ "name": "Edward Habermehl" }],
   "keyword": [{ "text": "HR+/HER2- breast cancer" }, { "text": "Palbociclib" }],
@@ -50,6 +50,10 @@
       "display": "Inclusion Criteria:\n\n          -  Signed informed consent prior to study specific procedures.\n\n          -  Age ≥18 years (or per national guidelines).\n\n          -  Pre- and postmenopausal women or men with Stage II (Stage IIA limited to max. 1000\n             patients) or Stage III early invasive breast cancer\n\n          -  Patients with multicentric and/or multifocal and/or bilateral early invasive breast\n             cancer are eligible if all histopathologically examined tumors meet pathologic\n             criteria for ER+ and/or PR+ and HER2-.\n\n          -  Patients must have histologically confirmed ER+ and/or PR+, HER2-, early invasive\n             breast cancer.\n\n          -  Patients must have undergone adequate (definitive) breast surgery for the current\n             malignancy.\n\n        FFPE tumor tissue block must be confirmed to be received at the central sample repository\n        prior to randomization.\n\n          -  ECOG performance status 0-1.\n\n          -  Patients must be able and willing to swallow and retain oral medication.\n\n          -  Serum or urine pregnancy test must be negative in premenopausal women within 14 days\n             of randomization, or in women with amenorrhea of less than 12 months at time of\n             randomization.\n\n          -  Patients who received neo/adjuvant therapy must be after last dose of chemotherapy\n             and/or biologic therapy and must have sufficient resolution of side effects.\n\n          -  Patients who received breast/axilla/post-mastectomy chest wall radiotherapy must be\n             after last dose of radiotherapy and must have sufficient resolution of side effects.\n\n          -  Patients must have sufficient resolution of any surgical side effects (no active wound\n             healing complications).\n\n        -Patients must either be initiating or have already started adjuvant hormonal treatment. -\n\n          -  Patients who already received neo/adjuvant endocrine therapy are eligible as long as\n             they are enrolled within 12 months of initial histological diagnosis and after\n             completing no more than 6 months of adjuvant endocrine therapy.\n\n          -  Absolute neutrophil count ≥ 1,500/µL\n\n          -  Platelets ≥ 100,000/ mm3\n\n          -  Hemoglobin ≥ 10g/dL\n\n          -  Total serum bilirubin ≤ ULN; or total bilirubin ≤ 3.0 × ULN with direct bilirubin\n             within normal range in patients with documented Gilbert's Syndrome.\n\n          -  Aspartate amino transferase (AST or SGOT) and alanine amino transferase (ALT or SGPT)\n             ≤ 1.5 × institutional ULN.\n\n          -  Serum creatinine below the upper limit of the institutional normal range (ULN) or\n             creatinine clearance ≥ 60 mL/min/1.73 m2 for patients with serum creatinine levels\n             above institutional ULN.\n\n        Exclusion Criteria:\n\n          -  Concurrent therapy with other Investigational Products.\n\n          -  Prior therapy with any CDK inhibitor.\n\n          -  Patients with Stage I or IV breast cancer are not eligible.\n\n          -  History of allergic reactions attributed to compounds of chemical or biologic\n             composition similar to palbociclib.\n\n          -  Patients receiving any medications or substances that are potent inhibitors or\n             inducers of\n\n          -  CYP3A isoenzymes within 7 days of randomization.\n\n          -  Uncontrolled intercurrent illness that would limit compliance with study requirements.\n\n          -  Pregnant women, or women of childbearing potential without a negative pregnancy test\n             within 14 days prior to randomization.\n\n          -  Patients with a history of any malignancy are ineligible\n\n          -  Patients who previously received endocrine therapy within 5 years prior to diagnosis\n             of the current malignancy.\n\n          -  Patients on antiretroviral therapy.\n\n          -  Patients with clinically significant history of any chronic liver disease.\n\n          -  Patients receiving concurrent exogenous hormone therapy (topical vaginal estrogen\n             therapy is allowable)."
     }
   ],
+  "period": {
+    "start": "2015-08-01T04:00:00.000Z",
+    "end": "2025-09-01T04:00:00.000Z"
+  },
   "description": "This is a prospective, two arm, international, multicenter, randomized, open-label Phase III\n      study evaluating the addition of 2 years of palbociclib to standard adjuvant endocrine\n      therapy for patients with HR+ / HER2- early breast cancer (EBC).\n\n      The purpose of the PALLAS study is to determine whether the addition of palbociclib to\n      adjuvant endocrine therapy will improve outcomes over endocrine therapy alone for HR+/HER2-\n      early breast cancer. Assessment of a variety of correlative analysis, including evaluation of\n      the effect of palbociclib in genomically defined tumor subgroups, is planned.",
   "phase": {
     "coding": [
@@ -84,34 +88,34 @@
       "type": "Location"
     }
   ],
-   "arm":[
-      {
-         "name":"Arm A",
-         "type":{
-            "coding":[
-               {
-                  "code":"Experimental",
-                  "display":"Experimental"
-               }
-            ],
-            "text":"Experimental"
-         },
-         "description":"Palbociclib at a dose of 125 mg orally once daily, Day 1 to Day 21 followed by 7 days off treatment in a 28-day cycle for a total duration of 2 years, in addition to standard adjuvant endocrine therapy for a duration of at least 5 years."
+  "arm": [
+    {
+      "name": "Arm A",
+      "type": {
+        "coding": [
+          {
+            "code": "Experimental",
+            "display": "Experimental"
+          }
+        ],
+        "text": "Experimental"
       },
-      {
-         "name":"Arm B",
-         "type":{
-            "coding":[
-               {
-                  "code":"Other",
-                  "display":"Other"
-               }
-            ],
-            "text":"Other"
-         },
-         "description":"Standard adjuvant endocrine therapy for a duration of at least 5 years."
-      }
-   ],
+      "description": "Palbociclib at a dose of 125 mg orally once daily, Day 1 to Day 21 followed by 7 days off treatment in a 28-day cycle for a total duration of 2 years, in addition to standard adjuvant endocrine therapy for a duration of at least 5 years."
+    },
+    {
+      "name": "Arm B",
+      "type": {
+        "coding": [
+          {
+            "code": "Other",
+            "display": "Other"
+          }
+        ],
+        "text": "Other"
+      },
+      "description": "Standard adjuvant endocrine therapy for a duration of at least 5 years."
+    }
+  ],
   "contained": [
     {
       "resourceType": "Location",

--- a/src/clinicaltrialsgov.ts
+++ b/src/clinicaltrialsgov.ts
@@ -1376,27 +1376,15 @@ export function updateResearchStudyWithClinicalStudy(
     if (study.start_date || study.completion_date) {
       // Because of the VariableDate, we need to normalize the dates
       const convertToDate = (study_date:VariableDateStruct):string | undefined => {
-        try {
-          if (typeof study_date == "string") {
-            if (study_date == "Unknown") return undefined
-            
-            const date = new Date(study_date);
+        if (typeof study_date == "string") {
+          const date = new Date(study_date);
 
-            return date.toString() == "Invalid Date" ? undefined : date.toISOString();
-          } else if (study_date?._){
-            if (study_date._ == "Unknown") return undefined
+          return date.toString() == "Invalid Date" ? undefined : date.toISOString();
+        } else {
+          const date = new Date(study_date._);
 
-            const date = new Date(study_date._);
-
-            return date.toString() == "Invalid Date" ? undefined : date.toISOString();
-          }
-        } catch (err) {
-          // Any errors -- we'll say it is undefined
-          return undefined
+          return date.toString() == "Invalid Date" ? undefined : date.toISOString();
         }
-
-        // Again when in doubt return undefined
-        return undefined;
       }
 
       // Set the period object as appropriate 

--- a/src/fhir-types.ts
+++ b/src/fhir-types.ts
@@ -154,6 +154,12 @@ export interface CodeableConcept {
   text?: string;
 }
 
+export interface Period {
+  start?: string;
+  end?: string;
+
+}
+
 export type ContactPointSystem = 'phone' | 'fax' | 'email' | 'pager' | 'url' | 'sms' | 'other';
 export type ContactPointUse = 'home' | 'work' | 'temp' | 'old' | 'mobile';
 
@@ -282,6 +288,7 @@ export interface ResearchStudy extends BaseResource {
   arm?: Arm[];
   objective?: Objective[];
   enrollment?: Reference[];
+  period?: Period;
   sponsor?: Reference;
   principalInvestigator?: Reference;
   site?: Reference[];


### PR DESCRIPTION
If there is no period for the study, the backup service will now try to obtain it by looking at CT.gov

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Make sure there is an update to service library reference in the service wrappers/template once this PR is merged.
- [ ]	Does an update need to be made to the engine?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
