### PR TITLE
Do not abort on server errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clinical-trial-matching-service",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Provides a core library for interacting with the clinical-trial-matching-engine",
   "homepage": "https://github.com/mcode/clinical-trial-matching-service",
   "bugs": "https://github.com/mcode/clinical-trial-matching-service/issues",

--- a/spec/clinicaltrialsgov.spec.ts
+++ b/spec/clinicaltrialsgov.spec.ts
@@ -765,7 +765,7 @@ describe('ClinicalTrialsGovService', () => {
           expect(scope.isDone()).toBeTrue();
         })
       )
-        .toBeRejected()
+        .toBeResolved()
         .then(() => {
           // Check to make sure the new cache entries do not still exist - the failure should remove them, but not the
           // non-pending one


### PR DESCRIPTION
This updates the ClinicalTrials.gov part of the service library so that if an error is returned from the server when attempting to load a clinical trial's data, it doesn't abort the entire process. Instead, the information is marked as invalid within the cache, and the affected clinical trial doesn't have data added.

**Submitter:**
- [x] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [x]	Does an update need to be made to the documentation with these changes?
- [ ]	Make sure there is an update to service library reference in the service wrappers/template once this PR is merged.
- [ ]	Does an update need to be made to the engine?
- [x] Was the new feature tested by unit tests?
- [x] Was the new feature tested by a manual, end-to-end test?
