### PR TITLE
Add in ability to take in take in SearchSet entries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clinical-trial-matching-service",
-  "version": "0.0.14",
+  "version": "0.1.0",
   "description": "Provides a core library for interacting with the clinical-trial-matching-engine",
   "homepage": "https://github.com/mcode/clinical-trial-matching-service",
   "bugs": "https://github.com/mcode/clinical-trial-matching-service/issues",

--- a/spec/clinicaltrialsgov.spec.ts
+++ b/spec/clinicaltrialsgov.spec.ts
@@ -644,12 +644,6 @@ describe('ClinicalTrialsGovService', () => {
     it('handles splitting requests', () => {
       // Basically, drop the limit to be very low, and make sure we get two calls
       service.maxTrialsPerRequest = 2;
-      const testStudies: ResearchStudy[] = [
-        createResearchStudy('test1', 'NCT00000001'),
-        createResearchStudy('test2', 'NCT00000002'),
-        createResearchStudy('test3', 'NCT00000003'),
-        createResearchStudy('test4', 'NCT00000004')
-      ];
 
       const testSearchSetEntries: SearchBundleEntry[] = [
         createSearchSetEntry('test1', 'NCT00000001'),
@@ -665,7 +659,7 @@ describe('ClinicalTrialsGovService', () => {
 
       service.getCachedClinicalStudy = getTrialSpy;
       return expectAsync(
-        service.updateResearchStudies(testStudies).then(() => {
+        service.updateSearchSetEntries(testSearchSetEntries).then(() => {
           expect(downloadTrialsSpy.calls.count()).toEqual(2);
           expect(downloadTrialsSpy.calls.argsFor(0)).toEqual([['NCT00000001', 'NCT00000002']]);
           expect(downloadTrialsSpy.calls.argsFor(1)).toEqual([['NCT00000003', 'NCT00000004']]);

--- a/spec/clinicaltrialsgov.spec.ts
+++ b/spec/clinicaltrialsgov.spec.ts
@@ -607,43 +607,38 @@ describe('ClinicalTrialsGovService', () => {
       });
     });
 
-        // These tests basically are only to ensure that all trials are properly visited when given.
-    it('updates all the given studies', () => {
-          // Our test studies contain the same NCT ID twice to make sure that works as expected, as well as a NCT ID that
-          // download spy will return null for to indicate a failure.
-          const testSearchSetEntries: SearchBundleEntry[] = [
-            createSearchSetEntry('dupe1', 'NCT00000001'),
-            createSearchSetEntry('missing', 'NCT00000002'),
-            createSearchSetEntry('dupe2', 'NCT00000001'),
-            createSearchSetEntry('singleton', 'NCT00000003', 0.5),
+    // These tests basically are only to ensure that all trials are properly visited when given.
+    it('updates all the given studies', async () => {
+      // Our test studies contain the same NCT ID twice to make sure that works as expected, as well as a NCT ID that
+      // download spy will return null for to indicate a failure.
+      const testSearchSetEntries: SearchBundleEntry[] = [
+        createSearchSetEntry('dupe1', 'NCT00000001'),
+        createSearchSetEntry('missing', 'NCT00000002'),
+        createSearchSetEntry('dupe2', 'NCT00000001'),
+        createSearchSetEntry('singleton', 'NCT00000003', 0.5)
+      ];
 
-          ]
+      const testStudy = createClinicalStudy();
+      const updateSpy = spyOn(service, 'updateResearchStudy');
+      const getTrialSpy = jasmine.createSpy('getCachedClinicalStudy').and.callFake((nctId: string) => {
+        return Promise.resolve(nctId === 'NCT00000002' ? null : testStudy);
+      });
 
-          const testStudy = createClinicalStudy();
-          const updateSpy = spyOn(service, 'updateResearchStudy');
-          const getTrialSpy = jasmine.createSpy('getCachedClinicalStudy').and.callFake((nctId: string) => {
-            return Promise.resolve(nctId === 'NCT00000002' ? null : testStudy);
-          });
-
-          service.getCachedClinicalStudy = getTrialSpy;
-          return expectAsync(
-            service.updateSearchSetEntries(testSearchSetEntries).then(() => {
-              expect(downloadTrialsSpy).toHaveBeenCalledOnceWith(['NCT00000001', 'NCT00000002', 'NCT00000003']);
-              // Update should have been called three times: twice for the NCT00000001 studies, and once for the NCT00000003 study
-              expect(updateSpy).toHaveBeenCalledWith(testSearchSetEntries[0].resource as ResearchStudy, testStudy);
-              expect(updateSpy).not.toHaveBeenCalledWith(testSearchSetEntries[1].resource as ResearchStudy, testStudy);
-              expect(updateSpy).toHaveBeenCalledWith(testSearchSetEntries[2].resource as ResearchStudy, testStudy);
-              expect(updateSpy).toHaveBeenCalledWith(testSearchSetEntries[3].resource as ResearchStudy, testStudy);
-            })
-          ).toBeResolved();
+      service.getCachedClinicalStudy = getTrialSpy;
+      await service.updateSearchSetEntries(testSearchSetEntries);
+      expect(downloadTrialsSpy).toHaveBeenCalledOnceWith(['NCT00000001', 'NCT00000002', 'NCT00000003']);
+      // Update should have been called three times: twice for the NCT00000001 studies, and once for the NCT00000003 study
+      expect(updateSpy).toHaveBeenCalledWith(testSearchSetEntries[0].resource as ResearchStudy, testStudy);
+      expect(updateSpy).not.toHaveBeenCalledWith(testSearchSetEntries[1].resource as ResearchStudy, testStudy);
+      expect(updateSpy).toHaveBeenCalledWith(testSearchSetEntries[2].resource as ResearchStudy, testStudy);
+      expect(updateSpy).toHaveBeenCalledWith(testSearchSetEntries[3].resource as ResearchStudy, testStudy);
     });
 
-    it('does nothing if no studies have NCT IDs', () => {
-      return expectAsync(
-        service.updateSearchSetEntries([ {resource: { resourceType: 'ResearchStudy', status: 'active' }, search: { mode: 'match', score: 0 }}]).then(() => {
-          expect(downloadTrialsSpy).not.toHaveBeenCalled();
-        })
-      ).toBeResolved();
+    it('does nothing if no studies have NCT IDs', async () => {
+      await service.updateSearchSetEntries([
+        { resource: { resourceType: 'ResearchStudy', status: 'active' }, search: { mode: 'match', score: 0 } }
+      ]);
+      expect(downloadTrialsSpy).not.toHaveBeenCalled();
     });
 
     it('handles splitting requests', () => {
@@ -660,15 +655,14 @@ describe('ClinicalTrialsGovService', () => {
         createSearchSetEntry('test1', 'NCT00000001'),
         createSearchSetEntry('test2', 'NCT00000002'),
         createSearchSetEntry('test3', 'NCT00000003'),
-        createSearchSetEntry('test4', 'NCT00000004', 0.5),
-
-      ]
+        createSearchSetEntry('test4', 'NCT00000004', 0.5)
+      ];
       const testStudy = createClinicalStudy();
       spyOn(service, 'updateResearchStudy');
       const getTrialSpy = jasmine.createSpy('getCachedClinicalStudy').and.callFake(() => {
         return Promise.resolve(testStudy);
       });
-      
+
       service.getCachedClinicalStudy = getTrialSpy;
       return expectAsync(
         service.updateResearchStudies(testStudies).then(() => {
@@ -678,7 +672,6 @@ describe('ClinicalTrialsGovService', () => {
         })
       ).toBeResolved();
     });
-      
   });
 
   // this functionality is currently unimplemented - this test exists solely to "cover" the method

--- a/spec/support/researchstudy-factory.ts
+++ b/spec/support/researchstudy-factory.ts
@@ -1,6 +1,7 @@
 import { CLINICAL_TRIAL_IDENTIFIER_CODING_SYSTEM_URL } from '../../src/clinicaltrialsgov';
 import type { ResearchStudy as IResearchStudy } from 'fhir/r4';
 import { ResearchStudy } from '../../src/research-study';
+import { SearchBundleEntry } from '../../src/searchset';
 
 export function createResearchStudyObject(nctId?: string): ResearchStudy {
   const result = new ResearchStudy(nctId ?? "test");
@@ -29,6 +30,17 @@ export function createResearchStudy(id: string, nctId?: string): IResearchStudy 
         value: nctId
       }
     ];
+  }
+  return result;
+}
+
+export function createSearchSetEntry(id: string, nctId?: string, score?: number): SearchBundleEntry {
+  const result:SearchBundleEntry = {
+    resource: createResearchStudy(id,nctId),
+    search: {
+      mode: "match",
+      score: score || 0
+    }
   }
   return result;
 }

--- a/spec/support/researchstudy-factory.ts
+++ b/spec/support/researchstudy-factory.ts
@@ -4,7 +4,7 @@ import { ResearchStudy } from '../../src/research-study';
 import { SearchBundleEntry } from '../../src/searchset';
 
 export function createResearchStudyObject(nctId?: string): ResearchStudy {
-  const result = new ResearchStudy(nctId ?? "test");
+  const result = new ResearchStudy(nctId ?? 'test');
   if (nctId) {
     result.identifier = [
       {
@@ -35,12 +35,12 @@ export function createResearchStudy(id: string, nctId?: string): IResearchStudy 
 }
 
 export function createSearchSetEntry(id: string, nctId?: string, score?: number): SearchBundleEntry {
-  const result:SearchBundleEntry = {
-    resource: createResearchStudy(id,nctId),
+  const result: SearchBundleEntry = {
+    resource: createResearchStudy(id, nctId),
     search: {
-      mode: "match",
+      mode: 'match',
       score: score || 0
     }
-  }
+  };
   return result;
 }

--- a/src/clinicaltrialsgov.ts
+++ b/src/clinicaltrialsgov.ts
@@ -18,7 +18,7 @@
 
 import { debuglog } from 'util';
 import { ResearchStudy } from 'fhir/r4';
-import {SearchBundleEntry as SearchSetEntry} from './searchset';
+import { SearchBundleEntry as SearchSetEntry } from './searchset';
 import { ClinicalTrialsGovAPI, Study } from './clinicaltrialsgov-api';
 import { updateResearchStudyWithClinicalStudy } from './study-fhir-converter';
 import * as sqlite from 'sqlite';
@@ -491,17 +491,17 @@ export class ClinicalTrialsGovService {
     }
   }
 
-  async updateSearchSetEntries(entries: SearchSetEntry[]):Promise<SearchSetEntry[]> {
-    const studies:ResearchStudy[] = entries.map(item => item.resource as ResearchStudy);
+  async updateSearchSetEntries(entries: SearchSetEntry[]): Promise<SearchSetEntry[]> {
+    const studies: ResearchStudy[] = entries.map((item) => item.resource as ResearchStudy);
 
     await this.ensureTrialsAvailable(studies);
 
     await Promise.all(
       entries.map((entry) => {
-       const nctId = findNCTNumber(entry.resource as ResearchStudy) || '';
-       return this.updateResearchStudyFromCache(nctId, entry.resource as ResearchStudy);
-
-      }));
+        const nctId = findNCTNumber(entry.resource as ResearchStudy) || '';
+        return this.updateResearchStudyFromCache(nctId, entry.resource as ResearchStudy);
+      })
+    );
 
     return entries;
   }


### PR DESCRIPTION
**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Make sure there is an update to service library reference in the service wrappers/template once this PR is merged.
- [ ]	Does an update need to be made to the engine?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
