### PR TITLE
Replace all data in a research study with data from CT.gov

### DIFF
--- a/spec/clinicaltrialsgov.spec.ts
+++ b/spec/clinicaltrialsgov.spec.ts
@@ -938,7 +938,7 @@ describe('ClinicalTrialsGovService', () => {
   });
 
   describe('#updateResearchStudy', () => {
-    it('forwards to updateResearchStudyWithClinicalStudy', () => {
+    it('forwards to createResearchStudyFromClinicalStudy', () => {
       const service = createMemoryCTGovService();
       const testResearchStudy = createResearchStudy('test');
       const testClinicalStudy = createClinicalStudy();

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -6,7 +6,7 @@ describe('index', () => {
     expect(ctms.ResearchStudy).toBeDefined();
     expect(ctms.ClinicalTrialMatchingService).toBeDefined();
     expect(ctms.ClinicalTrialsGovAPI).toBeDefined();
-    expect(ctms.updateResearchStudyWithClinicalStudy).toBeDefined();
+    expect(ctms.createResearchStudyFromClinicalStudy).toBeDefined();
     expect(ctms.CodeMapper).toBeDefined();
     expect(ctms.CodeSystemEnum).toBeDefined();
     expect(ctms.ClientError).toBeDefined();

--- a/src/clinicaltrialsgov.ts
+++ b/src/clinicaltrialsgov.ts
@@ -20,7 +20,7 @@ import { debuglog } from 'util';
 import { ResearchStudy } from 'fhir/r4';
 import { SearchBundleEntry as SearchSetEntry } from './searchset';
 import { ClinicalTrialsGovAPI, Study } from './clinicaltrialsgov-api';
-import { updateResearchStudyWithClinicalStudy } from './study-fhir-converter';
+import { createResearchStudyFromClinicalStudy } from './study-fhir-converter';
 import * as sqlite from 'sqlite';
 import * as sqlite3 from 'sqlite3';
 
@@ -690,7 +690,7 @@ export class ClinicalTrialsGovService {
    * @param clinicalStudy the clinical study to update it with
    */
   updateResearchStudy(researchStudy: ResearchStudy, clinicalStudy: Study): void {
-    updateResearchStudyWithClinicalStudy(researchStudy, clinicalStudy);
+    createResearchStudyFromClinicalStudy(clinicalStudy, researchStudy);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export { CodeMapper, CodeSystemEnum } from './codeMapper';
 export * from './mcodeextractor';
 export { Study } from './ctg-api';
 export { ClinicalTrialsGovAPI } from './clinicaltrialsgov-api';
-export { updateResearchStudyWithClinicalStudy } from './study-fhir-converter';
+export { createResearchStudyFromClinicalStudy } from './study-fhir-converter';
 
 // The export { v } from "mod" forms do not appear to work for types yet, so
 // they have to be imported and then exported...

--- a/src/study-fhir-converter.ts
+++ b/src/study-fhir-converter.ts
@@ -81,93 +81,86 @@ function convertArrayToCodeableConcept(trialConditions: string[]): CodeableConce
 }
 
 /**
- * Updates a research study with data from a clinical study off the ClinicalTrials.gov website. This will only update
- * fields that do not have data, it will not overwrite any existing data.
  *
- * Mapping as defined by https://www.hl7.org/fhir/researchstudy-mappings.html#clinicaltrials-gov
- *
- * @param result the research study to update
- * @param study the clinical study to use to update
+ * @param study the study to base the result on
+ * @param result if given, keeps whatever data is already in the result that
+ *   isn't in the ClinicalTrials.gov study object (all other data will be
+ *   overwritten on the passed object)
+ * @returns the resulting study, either a new object if result was
+ *   null/undefined, or the passed ResearchStudy
  */
-export function updateResearchStudyWithClinicalStudy(result: ResearchStudy, study: Study): ResearchStudy {
+export function createResearchStudyFromClinicalStudy(study: Study, result?: ResearchStudy): ResearchStudy {
+  if (!result) {
+    result = {
+      resourceType: 'ResearchStudy',
+      status: 'active'
+    };
+  }
+
   const protocolSection = study.protocolSection;
   // If there is no protocol section, we can't do anything.
   if (!protocolSection) {
     return result;
   }
-  if (!result.enrollment) {
-    const eligibility = protocolSection.eligibilityModule;
-    if (eligibility) {
-      const criteria = eligibility.eligibilityCriteria;
-      if (criteria) {
-        const group: Group = { resourceType: 'Group', id: 'group' + result.id, type: 'person', actual: false };
-        const reference = addContainedResource(result, group);
-        reference.display = criteria;
-        result.enrollment = [reference];
-      }
+
+  const eligibility = protocolSection.eligibilityModule;
+  if (eligibility) {
+    const criteria = eligibility.eligibilityCriteria;
+    if (criteria) {
+      const group: Group = { resourceType: 'Group', id: 'group' + result.id, type: 'person', actual: false };
+      const reference = addContainedResource(result, group);
+      reference.display = criteria;
+      result.enrollment = [reference];
     }
   }
-
-  if (!result.description) {
-    const briefSummary = protocolSection.descriptionModule?.briefSummary;
-    if (briefSummary) {
-      result.description = briefSummary;
-    }
+  const briefSummary = protocolSection.descriptionModule?.briefSummary;
+  if (briefSummary) {
+    result.description = briefSummary;
   }
 
-  if (!result.phase) {
-    const phase = protocolSection.designModule?.phases;
-    if (phase && phase.length > 0) {
-      // For now, just grab whatever the first phase is
-      // TODO: handle the somewhat weirder "phase-1-phase-2" items
-      const code = convertToResearchStudyPhase(phase[0]);
-      if (code) {
-        const display = code.replace(/-/g, ' ');
-        result.phase = {
-          coding: [
-            {
-              system: 'http://terminology.hl7.org/CodeSystem/research-study-phase',
-              code: code,
-              display: display
-            }
-          ],
-          text: display
-        };
-      }
+  const phase = protocolSection.designModule?.phases;
+  if (phase && phase.length > 0) {
+    // For now, just grab whatever the first phase is
+    // TODO: handle the somewhat weirder "phase-1-phase-2" items
+    const code = convertToResearchStudyPhase(phase[0]);
+    if (code) {
+      const display = code.replace(/-/g, ' ');
+      result.phase = {
+        coding: [
+          {
+            system: 'http://terminology.hl7.org/CodeSystem/research-study-phase',
+            code: code,
+            display: display
+          }
+        ],
+        text: display
+      };
     }
   }
 
   // ------- Category
   // Since we may not have all of the Study design in the result, we need to do a merge of data
-  const categories: CodeableConcept[] = result.category ? result.category : [];
-
-  // We need to determine what categories have already been declared.
-  const types = categories.map((item) => {
-    const sep = item.text?.split(':');
-    return sep ? sep[0] : '';
-  });
+  const categories: CodeableConcept[] = [];
 
   const studyType = study.protocolSection?.designModule?.studyType;
-  if (studyType && !types.includes('Study Type')) {
+  if (studyType) {
     categories.push({ text: 'Study Type: ' + convertToTitleCase(studyType) });
   }
 
   const designInfo = protocolSection.designModule?.designInfo;
   if (designInfo) {
-    if (!types.includes('Intervention Model')) {
-      if (designInfo.interventionModel) {
-        categories.push({ text: 'Intervention Model: ' + convertToTitleCase(designInfo.interventionModel) });
-      } else if (designInfo.interventionModelDescription) {
-        categories.push({ text: 'Intervention Model: ' + designInfo.interventionModelDescription });
-      }
+    if (designInfo.interventionModel) {
+      categories.push({ text: 'Intervention Model: ' + convertToTitleCase(designInfo.interventionModel) });
+    } else if (designInfo.interventionModelDescription) {
+      categories.push({ text: 'Intervention Model: ' + designInfo.interventionModelDescription });
     }
 
-    if (designInfo.primaryPurpose && !types.includes('Primary Purpose')) {
+    if (designInfo.primaryPurpose) {
       categories.push({ text: 'Primary Purpose: ' + convertToTitleCase(designInfo.primaryPurpose) });
     }
 
     const maskingInfo = designInfo.maskingInfo;
-    if (maskingInfo && !types.includes('Masking')) {
+    if (maskingInfo) {
       // It's unclear exactly how to convert this
       const masking = maskingInfo.masking ? convertToTitleCase(maskingInfo.masking) : maskingInfo.maskingDescription;
       if (masking) {
@@ -175,15 +168,15 @@ export function updateResearchStudyWithClinicalStudy(result: ResearchStudy, stud
       }
     }
 
-    if (designInfo.allocation && !types.includes('Allocation')) {
+    if (designInfo.allocation) {
       categories.push({ text: 'Allocation: ' + convertToTitleCase(designInfo.allocation) });
     }
 
-    if (designInfo.timePerspective && !types.includes('Time Perspective')) {
+    if (designInfo.timePerspective) {
       categories.push({ text: 'Time Perspective: ' + convertToTitleCase(designInfo.timePerspective) });
     }
 
-    if (designInfo.observationalModel && !types.includes('Observation Model')) {
+    if (designInfo.observationalModel) {
       categories.push({ text: 'Observation Model: ' + convertToTitleCase(designInfo.observationalModel) });
     }
   }
@@ -191,128 +184,98 @@ export function updateResearchStudyWithClinicalStudy(result: ResearchStudy, stud
   if (categories.length >= 1) result.category = categories;
   // ------- Category
 
-  // Right now, the default value for a research study is "active". If CT.G
-  // knows better, then allow it to override that.
-  if (!result.status || result.status == 'active') {
-    const overallStatus = protocolSection.statusModule?.lastKnownStatus;
-    if (overallStatus) {
-      const status = convertClincalStudyStatusToFHIRStatus(overallStatus);
-      if (typeof status !== 'undefined') result.status = status;
-    }
+  const overallStatus = protocolSection.statusModule?.lastKnownStatus;
+  if (overallStatus) {
+    const status = convertClincalStudyStatusToFHIRStatus(overallStatus);
+    if (typeof status !== 'undefined') result.status = status;
   }
 
-  if (!result.condition) {
-    if (protocolSection.conditionsModule?.conditions) {
-      result.condition = convertArrayToCodeableConcept(protocolSection.conditionsModule?.conditions);
-    }
+  if (protocolSection.conditionsModule?.conditions) {
+    result.condition = convertArrayToCodeableConcept(protocolSection.conditionsModule?.conditions);
   }
 
-  if (!result.site) {
-    const locations = protocolSection.contactsLocationsModule?.locations;
-    if (locations) {
-      let index = 0;
-      for (const location of locations) {
-        if (typeof location === 'object' && location != null) {
-          const fhirLocation: Location = { resourceType: 'Location', id: 'location-' + index++ };
-          if (location.status) fhirLocation.status = convertRecruitmentStatusToLocationStatus(location.status);
-          if (location.facility) fhirLocation.name = location.facility;
-          if (location.city && location.country) {
-            // Also add the address information
-            fhirLocation.address = { use: 'work', city: location.city, country: location.country };
-            if (location.state) {
-              fhirLocation.address.state = location.state;
-            }
-            if (location.zip) {
-              fhirLocation.address.postalCode = location.zip;
-            }
+  const locations = protocolSection.contactsLocationsModule?.locations;
+  if (locations) {
+    let index = 0;
+    for (const location of locations) {
+      if (typeof location === 'object' && location != null) {
+        const fhirLocation: Location = { resourceType: 'Location', id: 'location-' + index++ };
+        if (location.status) fhirLocation.status = convertRecruitmentStatusToLocationStatus(location.status);
+        if (location.facility) fhirLocation.name = location.facility;
+        if (location.city && location.country) {
+          // Also add the address information
+          fhirLocation.address = { use: 'work', city: location.city, country: location.country };
+          if (location.state) {
+            fhirLocation.address.state = location.state;
           }
-          // If we have an exact GPS coordinate, add that, too
-          const geoPoint = location.geoPoint;
-          if (geoPoint && typeof geoPoint.lat === 'number' && typeof geoPoint.lon === 'number') {
-            fhirLocation.position = {
-              longitude: geoPoint.lon,
-              latitude: geoPoint.lat
-            };
+          if (location.zip) {
+            fhirLocation.address.postalCode = location.zip;
           }
-          if (location.contacts) {
-            for (const contact of location.contacts) {
-              if (contact.email) {
-                addToContainer<Location, ContactPoint, 'telecom'>(fhirLocation, 'telecom', {
-                  system: 'email',
-                  value: contact.email,
-                  use: 'work'
-                });
-              }
-              if (contact.phone) {
-                addToContainer<Location, ContactPoint, 'telecom'>(fhirLocation, 'telecom', {
-                  system: 'phone',
-                  value: contact.phone,
-                  use: 'work'
-                });
-              }
-            }
-          }
-          addToContainer<ResearchStudy, Reference, 'site'>(result, 'site', addContainedResource(result, fhirLocation));
         }
-      }
-    }
-  }
-
-  if (!result.arm) {
-    const armGroups = protocolSection.armsInterventionsModule?.armGroups;
-    if (armGroups) {
-      for (const studyArm of armGroups) {
-        const label = studyArm.label;
-        if (label) {
-          const arm: ResearchStudyArm = {
-            name: label,
-            ...(studyArm.type && {
-              type: {
-                coding: [
-                  {
-                    // It's unclear if there is any coding system for this, so for now, make it look like FHIR
-                    code: studyArm.type.replace(/_/g, '-').toLowerCase(),
-                    display: convertToTitleCase(studyArm.type)
-                  }
-                ],
-                text: convertToTitleCase(studyArm.type)
-              }
-            }),
-            ...(studyArm.description && { description: studyArm.description })
+        // If we have an exact GPS coordinate, add that, too
+        const geoPoint = location.geoPoint;
+        if (geoPoint && typeof geoPoint.lat === 'number' && typeof geoPoint.lon === 'number') {
+          fhirLocation.position = {
+            longitude: geoPoint.lon,
+            latitude: geoPoint.lat
           };
-
-          addToContainer<ResearchStudy, ResearchStudyArm, 'arm'>(result, 'arm', arm);
         }
+        if (location.contacts) {
+          for (const contact of location.contacts) {
+            if (contact.email) {
+              addToContainer<Location, ContactPoint, 'telecom'>(fhirLocation, 'telecom', {
+                system: 'email',
+                value: contact.email,
+                use: 'work'
+              });
+            }
+            if (contact.phone) {
+              addToContainer<Location, ContactPoint, 'telecom'>(fhirLocation, 'telecom', {
+                system: 'phone',
+                value: contact.phone,
+                use: 'work'
+              });
+            }
+          }
+        }
+        addToContainer<ResearchStudy, Reference, 'site'>(result, 'site', addContainedResource(result, fhirLocation));
       }
     }
   }
 
-  if (!result.protocol) {
-    const interventions = protocolSection.armsInterventionsModule?.interventions;
-    if (interventions) {
-      let index = 0;
-      for (const intervention of interventions) {
-        if (intervention.armGroupLabels) {
-          for (const armGroupLabel of intervention.armGroupLabels) {
-            let plan: PlanDefinition = { resourceType: 'PlanDefinition', status: 'unknown', id: 'plan-' + index++ };
+  const armGroups = protocolSection.armsInterventionsModule?.armGroups;
+  if (armGroups) {
+    for (const studyArm of armGroups) {
+      const label = studyArm.label;
+      if (label) {
+        const arm: ResearchStudyArm = {
+          name: label,
+          ...(studyArm.type && {
+            type: {
+              coding: [
+                {
+                  // It's unclear if there is any coding system for this, so for now, make it look like FHIR
+                  code: studyArm.type.replace(/_/g, '-').toLowerCase(),
+                  display: convertToTitleCase(studyArm.type)
+                }
+              ],
+              text: convertToTitleCase(studyArm.type)
+            }
+          }),
+          ...(studyArm.description && { description: studyArm.description })
+        };
 
-            plan = {
-              ...plan,
-              ...(intervention.description && { description: intervention.description }),
-              ...(intervention.name && { title: intervention.name }),
-              ...(intervention.otherNames &&
-                intervention.otherNames.length > 0 && { subtitle: intervention.otherNames[0] }),
-              ...(intervention.type && { type: { text: convertToTitleCase(intervention.type) } }),
-              ...{ subjectCodeableConcept: { text: armGroupLabel } }
-            };
+        addToContainer<ResearchStudy, ResearchStudyArm, 'arm'>(result, 'arm', arm);
+      }
+    }
+  }
 
-            addToContainer<ResearchStudy, Reference, 'protocol'>(
-              result,
-              'protocol',
-              addContainedResource(result, plan)
-            );
-          }
-        } else {
+  const interventions = protocolSection.armsInterventionsModule?.interventions;
+  if (interventions) {
+    let index = 0;
+    for (const intervention of interventions) {
+      if (intervention.armGroupLabels) {
+        for (const armGroupLabel of intervention.armGroupLabels) {
           let plan: PlanDefinition = { resourceType: 'PlanDefinition', status: 'unknown', id: 'plan-' + index++ };
 
           plan = {
@@ -321,57 +284,66 @@ export function updateResearchStudyWithClinicalStudy(result: ResearchStudy, stud
             ...(intervention.name && { title: intervention.name }),
             ...(intervention.otherNames &&
               intervention.otherNames.length > 0 && { subtitle: intervention.otherNames[0] }),
-            ...(intervention.type && { type: { text: convertToTitleCase(intervention.type) } })
+            ...(intervention.type && { type: { text: convertToTitleCase(intervention.type) } }),
+            ...{ subjectCodeableConcept: { text: armGroupLabel } }
           };
 
           addToContainer<ResearchStudy, Reference, 'protocol'>(result, 'protocol', addContainedResource(result, plan));
         }
+      } else {
+        let plan: PlanDefinition = { resourceType: 'PlanDefinition', status: 'unknown', id: 'plan-' + index++ };
+
+        plan = {
+          ...plan,
+          ...(intervention.description && { description: intervention.description }),
+          ...(intervention.name && { title: intervention.name }),
+          ...(intervention.otherNames &&
+            intervention.otherNames.length > 0 && { subtitle: intervention.otherNames[0] }),
+          ...(intervention.type && { type: { text: convertToTitleCase(intervention.type) } })
+        };
+
+        addToContainer<ResearchStudy, Reference, 'protocol'>(result, 'protocol', addContainedResource(result, plan));
       }
     }
   }
 
-  if (!result.contact) {
-    const contacts = protocolSection.contactsLocationsModule?.centralContacts;
+  const contacts = protocolSection.contactsLocationsModule?.centralContacts;
 
-    if (contacts) {
-      for (const contact of contacts) {
-        if (contact != undefined) {
-          const contactName = contact.name;
-          if (contactName) {
-            const fhirContact: ContactDetail = { name: contactName };
-            if (contact.email) {
-              addToContainer<ContactDetail, ContactPoint, 'telecom'>(fhirContact, 'telecom', {
-                system: 'email',
-                value: contact.email,
-                use: 'work'
-              });
-            }
-            if (contact.phone) {
-              addToContainer<ContactDetail, ContactPoint, 'telecom'>(fhirContact, 'telecom', {
-                system: 'phone',
-                value: contact.phone,
-                use: 'work'
-              });
-            }
-            addToContainer<ResearchStudy, ContactDetail, 'contact'>(result, 'contact', fhirContact);
+  if (contacts) {
+    for (const contact of contacts) {
+      if (contact != undefined) {
+        const contactName = contact.name;
+        if (contactName) {
+          const fhirContact: ContactDetail = { name: contactName };
+          if (contact.email) {
+            addToContainer<ContactDetail, ContactPoint, 'telecom'>(fhirContact, 'telecom', {
+              system: 'email',
+              value: contact.email,
+              use: 'work'
+            });
           }
+          if (contact.phone) {
+            addToContainer<ContactDetail, ContactPoint, 'telecom'>(fhirContact, 'telecom', {
+              system: 'phone',
+              value: contact.phone,
+              use: 'work'
+            });
+          }
+          addToContainer<ResearchStudy, ContactDetail, 'contact'>(result, 'contact', fhirContact);
         }
       }
     }
   }
+  const startDate = protocolSection.statusModule?.startDateStruct?.date;
+  const completionDate = protocolSection.statusModule?.completionDateStruct?.date;
+  if (startDate || completionDate) {
+    // Set the period object as appropriate
+    const period = {
+      ...(startDate && isFhirDate(startDate) && { start: startDate }),
+      ...(completionDate && isFhirDate(completionDate) && { end: completionDate })
+    };
 
-  if (!result.period) {
-    const startDate = protocolSection.statusModule?.startDateStruct?.date;
-    const completionDate = protocolSection.statusModule?.completionDateStruct?.date;
-    if (startDate || completionDate) {
-      // Set the period object as appropriate
-      const period = {
-        ...(startDate && isFhirDate(startDate) && { start: startDate }),
-        ...(completionDate && isFhirDate(completionDate) && { end: completionDate })
-      };
-
-      if (Object.keys(period).length != 0) result.period = period;
-    }
+    if (Object.keys(period).length != 0) result.period = period;
   }
 
   return result;


### PR DESCRIPTION
Rather than attempt to update data from the matching service, this replaces it with a function that instead replaces any existing data with data from the ClinicalTrials.gov API. (Note that matching services should still attempt to fill in as much data as they can, as the CT.gov data can only be used if the trial exists on CT.gov.)